### PR TITLE
Fix a bug where TextType content got newlines it shouldn't have

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
 addons:
   apt:
     sources:
-      - sourceline: 'ppa:jeroen/jq'
+      - sourceline: 'ppa:opencpu/jq'
     packages:
       - librdf0-dev
       - libv8-dev

--- a/R/as_jsonlist.R
+++ b/R/as_jsonlist.R
@@ -24,7 +24,7 @@ as_jsonlist.xml_node <- function(x, ns = character()) {
   key <- xml_name(x)
   ## Treat <para> and <section> as literals
   if(key %in% c("para", "section")){
-    return(paste(as.character(xml_contents(x)), collapse = "\n"))
+    return(paste(as.character(xml_contents(x)), collapse = ""))
   }
 
   contents <- xml2::xml_contents(x)


### PR DESCRIPTION
@jeanetteclark and others found this while adding subscripts to
an EML document. What happens is that as_jsonlist is reading in
the contents of TextType `para` and `section` elements, and
converting them to literal XML strings with this code.

`<para>H<subscript>2</subscript>O</para>` gets turned into

```
para
  H
  <subscript>2</subscript>
  O
```
and calling as.character on the above followed by a paste with
collapse = "\n" introduces newlines between each child of the para.
This isn't a huge issue for most uses cases but, when rendering to
HTML via XSLT, you end up with spaces between the H and the 2
because browsers are getting the the newline and converting it to
whitespace.

Fixes https://github.com/ropensci/EML/issues/282