### PR TITLE
Fix validation error.

### DIFF
--- a/R/eml_validate.R
+++ b/R/eml_validate.R
@@ -116,7 +116,7 @@ eml_additional_validation <- function(eml,
 
   # Elements which contain an annotation child element MUST contain an id attribute,
   # unless the containing annotation element contains a references attribute
-  annot_without_ref <- xml2::xml_find_all(doc, "//annotation[not(references)]/..")
+  annot_without_ref <- xml2::xml_find_all(doc, "//annotation[not(@references)]/..")
   if(any(lapply(xml_attrs(annot_without_ref, "id"), length) == 0))
     error_log <- c(error_log,
                    paste("parent of any annotation must have id",


### PR DESCRIPTION
XPath was referencing the element rather than the attribute `references`. Closes #46.

There may be other errors as well, but this one was definite in my mind.