### PR TITLE
Let eml_version take a version string without the eml- prefix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,7 +17,9 @@ User-facing changes:
   See [#44](https://github.com/ropensci/emld/issues/44) & [#45](https://github.com/ropensci/emld/issues/45).
 
 - `emld::eml_validate` no longer depends on `schemaLocation` to determine the correct XSD to use during schema validation and now uses two helpers (See below) to find the correct schema file. See [#52](https://github.com/ropensci/emld/issues/44) & [#45](https://github.com/ropensci/emld/issues/53).
-      
+- `eml_version` now allows specifying the version without the `eml-` prefix, like `eml_version("2.1.1"), and will throw a warning when it gets output that doesn't 'look right rather than silently failing.
+- `eml_version` now shows an interactive menu when called with no arguments (`eml_version()`) from which you can choose your desired version. Note that, when used non-interactively (i.e., in scripts), calling `eml_version()` will just return the current value of the `emld_db` option or `eml-2.2.0` when that option is not set.
+
 Developer-facing (non-exported) changes:
 
 - Added two new helper methods:

--- a/R/eml_version.R
+++ b/R/eml_version.R
@@ -3,12 +3,14 @@
 #' Set or check the EML version default
 #'
 #' @param version EML version, currently either eml-2.2.0 (current version), or
-#' eml-2.1.1
+#' eml-2.1.1. The 'eml-' prefix can be omitted.
 #' @return returns the EML version string. As a side-effect, sets the
 #' requested version as the default version by setting the `emld_db`
 #' variable in [options()].
 #' @examples
 #' eml_version()
+#' eml_version("2.1.1")
+#' eml_version("eml-2.1.1")
 #'
 #' @export
 eml_version <- function(version = getOption("emld_db", "eml-2.2.0")){
@@ -16,15 +18,24 @@ eml_version <- function(version = getOption("emld_db", "eml-2.2.0")){
     version <- ask_eml_version()
   }
 
-  # Warn if the user provides a version that doesn't follow the form eml-x.y.z
-  if(!grepl("eml\\-[\\d\\.]+", version, perl = TRUE)) {
-    warning("Your provided version of '", version, "' does not look like a valid ",
-            "version string. Be sure it starts with 'eml-' and ends with the ",
-            "schema version. e.g., for EML 2.1.1, use 'eml-2.1.1'.")
+  out <- version
+
+  # Add eml- prefix if necessary so the user can just provide "2.1.1" to get
+  # eml-2.1.1 back
+  if (!grepl("^eml-", out)) {
+    out <- paste0("eml-", out)
   }
 
-  options(emld_db = version)
-  version
+  # Warn if the user provides a version that doesn't follow the form x[.y.z]
+  if(!grepl("eml-[\\d\\.]+", out, perl = TRUE)) {
+    warning("Your provided version of '", version, "' does not look like a ",
+            "valid version string. Be sure you specify a value like '2.1.1' ",
+            "or 'eml-2.1.1'. The 'eml-' is optional.")
+  }
+
+
+  options(emld_db = out)
+  out
 }
 
 
@@ -41,7 +52,7 @@ ask_eml_version <- function() {
          " Your EML version has not been changed.")
   }
 
-  paste0("eml-", options[choice])
+  options[choice]
 }
 
 #' Get the XML namespace for a version of EML

--- a/man/eml_version.Rd
+++ b/man/eml_version.Rd
@@ -8,7 +8,7 @@ eml_version(version = getOption("emld_db", "eml-2.2.0"))
 }
 \arguments{
 \item{version}{EML version, currently either eml-2.2.0 (current version), or
-eml-2.1.1}
+eml-2.1.1. The 'eml-' prefix can be omitted.}
 }
 \value{
 returns the EML version string. As a side-effect, sets the
@@ -20,5 +20,7 @@ Set or check the EML version default
 }
 \examples{
 eml_version()
+eml_version("2.1.1")
+eml_version("eml-2.1.1")
 
 }

--- a/tests/testthat/test-version.R
+++ b/tests/testthat/test-version.R
@@ -10,9 +10,11 @@ test_that("we can get the namespace for different EML versions", {
 test_that("we can set the EML version", {
   expect_equal(eml_version("eml-2.1.1"), "eml-2.1.1")
   expect_equal(eml_version("eml-2.2.0"), "eml-2.2.0")
+  expect_equal(eml_version("2.1.1"), "eml-2.1.1")
+  expect_equal(eml_version("2.2.0"), "eml-2.2.0")
 })
 
 test_that("we throw a warning when a user specifies an invalid version", {
   expect_warning(eml_version("a"))
-  expect_warning(eml_version("2.1.1"))
+  expect_warning(eml_version("eml2.1.1"))
 })


### PR DESCRIPTION
Follow-up of #58, specifically comment https://github.com/ropensci/emld/pull/58#issuecomment-639167817.