### PR TITLE
Make validate_units use the right eml-unitDictionary

### DIFF
--- a/R/validate_units.R
+++ b/R/validate_units.R
@@ -12,8 +12,12 @@ validate_units <- function(eml,
     xml2::xml_find_all(doc, "//customUnit", ns = ns),
     trim = TRUE))
 
+  # Read in the version of eml-unitDictionary.xml to match this document's
+  # schema version
+  root_schema <- guess_root_schema(eml)
+
   standard <- xml2::read_xml(system.file("tests",
-    getOption("emld_db"),
+    paste(root_schema$module, root_schema$version, sep = "-"),
     "eml-unitDictionary.xml",
     package = "emld"
   ))

--- a/inst/tests/eml-2.1.1/invalid/eml-2.1.1-invalidunit.xml
+++ b/inst/tests/eml-2.1.1/invalid/eml-2.1.1-invalidunit.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<eml:eml packageId="eml.1.1" system="knb" xmlns:eml="eml://ecoinformatics.org/eml-2.1.1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1" xsi:schemaLocation="eml://ecoinformatics.org/eml-2.1.1 ../eml.xsd">
+  <dataset>
+    <title>EML 2.1.1 invalid units test</title>
+    <creator id="example.user">
+      <individualName>
+        <givenName>Example</givenName>
+        <surName>User</surName>
+      </individualName>
+    </creator>
+    <contact>
+      <references>example.user</references>
+    </contact>
+    <dataTable id="xyz">
+      <entityName>entity</entityName>
+      <entityDescription>entity description</entityDescription>
+      <attributeList id="at.1">
+        <attribute id="att.1">
+          <attributeName>attribute1</attributeName>
+          <attributeDefinition>attribute1definition</attributeDefinition>
+          <storageType>float</storageType>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>milligramPerLiter</standardUnit>
+              </unit>
+              <precision>0.1</precision>
+              <numericDomain id="nd.5">
+                <numberType>real</numberType>
+                <bounds>
+                  <minimum exclusive="true">0</minimum>
+                </bounds>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+    </dataTable>
+  </dataset>
+</eml:eml>

--- a/inst/tests/eml-2.2.0/eml-2.2.0-milligramPerLiter.xml
+++ b/inst/tests/eml-2.2.0/eml-2.2.0-milligramPerLiter.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<eml:eml packageId="eml.1.1" system="knb" xmlns:eml="https://eml.ecoinformatics.org/eml-2.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.1">
+  <dataset>
+    <title>EML 2.2.0 milligramPerLiter test</title>
+    <creator id="example.user">
+      <individualName>
+        <givenName>Example</givenName>
+        <surName>User</surName>
+      </individualName>
+    </creator>
+    <contact>
+      <references>example.user</references>
+    </contact>
+    <dataTable id="xyz">
+      <entityName>entity</entityName>
+      <entityDescription>entity description</entityDescription>
+      <attributeList id="at.1">
+        <attribute id="att.1">
+          <attributeName>attribute1</attributeName>
+          <attributeDefinition>attribute1definition</attributeDefinition>
+          <storageType>float</storageType>
+          <measurementScale>
+            <ratio>
+              <unit>
+                <standardUnit>milligramPerLiter</standardUnit>
+              </unit>
+              <precision>0.1</precision>
+              <numericDomain id="nd.5">
+                <numberType>real</numberType>
+                <bounds>
+                  <minimum exclusive="true">0</minimum>
+                </bounds>
+              </numericDomain>
+            </ratio>
+          </measurementScale>
+        </attribute>
+      </attributeList>
+    </dataTable>
+  </dataset>
+</eml:eml>

--- a/inst/tests/eml-2.2.0/eml-unitDictionary.xml
+++ b/inst/tests/eml-2.2.0/eml-unitDictionary.xml
@@ -33,38 +33,45 @@
     Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 -->
 <stmml:unitList xmlns:stmml="http://www.xml-cml.org/schema/stmml-1.2"
-                xmlns:sch="http://www.ascc.net/xml/schematron"
-                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-                xmlns="http://www.xml-cml.org/schema/stmml-1.2"
-                xsi:schemaLocation="http://www.xml-cml.org/schema/stmml-1.2 xsd/stmml.xsd">
-<!-- ======================================================================= -->
-<!-- ========================= fundamental types =========================== -->
-<!-- ======================================================================= -->
-  <unitType id="length" name="length"> <!--meter-->
+  xmlns:sch="http://www.ascc.net/xml/schematron"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.xml-cml.org/schema/stmml-1.2"
+  xsi:schemaLocation="http://www.xml-cml.org/schema/stmml-1.2 xsd/stmml.xsd">
+  <!-- ======================================================================= -->
+  <!-- ========================= fundamental types =========================== -->
+  <!-- ======================================================================= -->
+  <unitType id="length" name="length">
+    <!--meter-->
     <dimension name="length"/>
   </unitType>
 
-  <unitType id="time" name="time"> <!--second-->
+  <unitType id="time" name="time">
+    <!--second-->
     <dimension name="time"/>
   </unitType>
 
-  <unitType id="mass" name="mass"> <!--kilogram-->
+  <unitType id="mass" name="mass">
+    <!--kilogram-->
     <dimension name="mass"/>
   </unitType>
 
-  <unitType id="current" name="current"> <!--ampere-->
+  <unitType id="current" name="current">
+    <!--ampere-->
     <dimension name="current"/>
   </unitType>
 
-  <unitType id="temperature" name="temperature"> <!--kelvin-->
+  <unitType id="temperature" name="temperature">
+    <!--kelvin-->
     <dimension name="temperature"/>
   </unitType>
 
-  <unitType id="amount" name="amount"> <!--mole-->
+  <unitType id="amount" name="amount">
+    <!--mole-->
     <dimension name="amount"/>
   </unitType>
 
-  <unitType id="luminosity" name="luminosity"> <!--candela-->
+  <unitType id="luminosity" name="luminosity">
+    <!--candela-->
     <dimension name="luminosity"/>
   </unitType>
 
@@ -72,986 +79,2042 @@
     <dimension name="dimensionless"/>
   </unitType>
 
-  <unitType id="angle" name="angle"> <!--radian-->
+  <unitType id="angle" name="angle">
+    <!--radian-->
     <dimension name="angle"/>
   </unitType>
 
-<!-- ======================================================================= -->
-<!-- ========================== derived types ============================== -->
-<!-- ======================================================================= -->
+  <!-- ======================================================================= -->
+  <!-- ========================== derived types ============================== -->
+  <!-- ======================================================================= -->
 
-  <unitType id="acceleration" name="acceleration"> <!--metersPerSecondSquared-->
+  <unitType id="acceleration" name="acceleration">
+    <!--metersPerSecondSquared-->
     <dimension name="length"/>
     <dimension name="time" power="-2"/>
   </unitType>
 
-  <unitType id="charge" name="charge"> <!--coulomb-->
+  <unitType id="charge" name="charge">
+    <!--coulomb-->
     <dimension name="current"/>
     <dimension name="time" power="1"/>
   </unitType>
 
-  <unitType id="magneticFieldStrength" name="magneticFieldStrength"> <!--amperePerMeter-->
+  <unitType id="magneticFieldStrength" name="magneticFieldStrength">
+    <!--amperePerMeter-->
     <dimension name="current"/>
     <dimension name="length" power="-1"/>
   </unitType>
 
-  <unitType id="currentDensity" name="currentDensity"> <!--amperePerSquareMeter-->
+  <unitType id="currentDensity" name="currentDensity">
+    <!--amperePerSquareMeter-->
     <dimension name="current"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="area" name="area"> <!--squareMeters-->
+  <unitType id="area" name="area">
+    <!--squareMeters-->
     <dimension name="length" power="2"/>
   </unitType>
 
-  <unitType id="lengthReciprocal" name="lengthReciprocal"> <!--waveNumber-->
+  <unitType id="lengthReciprocal" name="lengthReciprocal">
+    <!--waveNumber-->
     <dimension name="length" power="-1"/>
   </unitType>
 
-  <unitType id="frequency" name="frequency"> <!--hertz-->
+  <unitType id="frequency" name="frequency">
+    <!--hertz-->
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="volume" name="volume"> <!--cubicMeter-->
+  <unitType id="volume" name="volume">
+    <!--cubicMeter-->
     <dimension name="length" power="3"/>
   </unitType>
 
-  <unitType id="volumetricArea" name="volumetricArea"> <!--litersPerSquareMeter-->
+  <unitType id="volumetricArea" name="volumetricArea">
+    <!--litersPerSquareMeter-->
     <dimension name="length" power="3"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="speed" name="speed"> <!--metersPerSecond-->
+  <unitType id="speed" name="speed">
+    <!--metersPerSecond-->
     <dimension name="length"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="massDensity" name="massDensity"> <!--kilogramPerCubicMeter-->
+  <unitType id="massDensity" name="massDensity">
+    <!--kilogramPerCubicMeter-->
     <dimension name="mass"/>
     <dimension name="length" power="-3"/>
   </unitType>
 
-  <unitType id="massPerMass" name="massPerMass"> <!--gramsPerGram-->
+  <unitType id="massPerMass" name="massPerMass">
+    <!--gramsPerGram-->
     <dimension name="mass"/>
     <dimension name="mass" power="-1"/>
   </unitType>
+  
+  <unitType id="massPerMassRate" name="massPerMassRate">
+    <!--gramsPerGramPerTime-->
+    <dimension name="mass"/>
+    <dimension name="mass" power="-1"/>
+    <dimension name="time" power="-1"/>  
+  </unitType>
 
-  <unitType id="volumePerVolume" name="volumePerVolume"> <!--cubicCentimetersPerCubicCentimeter-->
+
+  <unitType id="volumePerVolume" name="volumePerVolume">
+    <!--cubicCentimetersPerCubicCentimeter-->
     <dimension name="length" power="3"/>
     <dimension name="mass" power="-3"/>
   </unitType>
 
-  <unitType id="volumetricRate" name="volumetricRate"> <!--litersPerSecond-->
+  <unitType id="volumetricRate" name="volumetricRate">
+    <!--litersPerSecond-->
     <dimension name="length" power="3"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="volumetricMassDensityRate" name="volumetricMassDensityRate"> <!--gramsPerLiterPerDay-->
+  <unitType id="volumetricMassDensityRate" name="volumetricMassDensityRate">
+    <!--gramsPerLiterPerDay-->
     <dimension name="mass"/>
     <dimension name="length" power="-3"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="arealMassDensityRate" name="arealMassDensityRate"> <!--kilogramsPerMeterSquaredPerSecond-->
+  <unitType id="massFlux" name="massFlux">
+    <!--kilogramsPerMeterSquaredPerSecond-->
     <dimension name="mass"/>
     <dimension name="length" power="-2"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="specificVolume" name="specificVolume"> <!--cubicMeterPerKilogram-->
+  <unitType id="specificVolume" name="specificVolume">
+    <!--cubicMeterPerKilogram-->
     <dimension name="mass" power="-1"/>
     <dimension name="length" power="3"/>
   </unitType>
 
-  <unitType id="amountOfSubstanceConcentration" name="amountOfSubstanceConcentration"> <!--molePerCubicMeter-->
+  <unitType id="amountOfSubstanceConcentration" name="amountOfSubstanceConcentration">
+    <!--molePerCubicMeter-->
     <dimension name="amount"/>
     <dimension name="length" power="-3"/>
   </unitType>
 
-  <unitType id="amountOfSubstanceWeight" name="amountOfSubstanceWeight"> <!--molesPerKilogram-->
+  <unitType id="amountOfSubstanceWeight" name="amountOfSubstanceWeight">
+    <!--molesPerKilogram-->
     <dimension name="amount"/>
     <dimension name="mass" power="-1"/>
   </unitType>
 
-  <unitType id="amountOfSubstanceWeightFlux" name="amountOfSubstanceWeightFlux"> <!--molesPerKilogramPerSecond-->
+  <unitType id="amountOfSubstanceWeightRate" name="amountOfSubstanceWeightRate">
+    <!--molesPerKilogramPerSecond-->
     <dimension name="amount"/>
     <dimension name="mass" power="-1"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="massFlux" name="massFlux"> <!--kilogramsPerSecond-->
+  <unitType id="massRate" name="massRate">
+    <!--kilogramsPerSecond-->
     <dimension name="mass"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="luminance" name="luminance"> <!--candelaPerSquareMeter-->
+  <unitType id="luminance" name="luminance">
+    <!--candelaPerSquareMeter-->
     <dimension name="luminosity"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="volumetricDensity" name="volumetricDensity"> <!--numberPerMeterCubed-->
+  <unitType id="volumetricDensity" name="volumetricDensity">
+    <!--numberPerMeterCubed-->
     <dimension name="dimensionless"/>
     <dimension name="length" power="-3"/>
   </unitType>
 
-  <unitType id="arealDensity" name="arealDensity"> <!--numberPerMeterSquared-->
+  <unitType id="arealDensity" name="arealDensity">
+    <!--numberPerMeterSquared-->
     <dimension name="dimensionless"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="arealMassDensity" name="arealMassDensity"> <!--kilogramsPerSquareMeter-->
+  <unitType id="arealMassDensity" name="arealMassDensity">
+    <!--kilogramPerSquareMeter-->
     <dimension name="mass"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="specificArea" name="specificArea"> <!--squareMeterPerKilogram-->
+  <unitType id="specificArea" name="specificArea">
+    <!--squareMeterPerKilogram-->
     <dimension name="mass" power="-1"/>
     <dimension name="length" power="2"/>
   </unitType>
 
-  <unitType id="force" name="force"> <!--newton-->
+  <unitType id="force" name="force">
+    <!--newton-->
     <dimension name="mass"/>
     <dimension name="length"/>
     <dimension name="time" power="-2"/>
   </unitType>
 
-  <unitType id="energy" name="energy"> <!--joule-->
+  <unitType id="energy" name="energy">
+    <!--joule-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-2"/>
   </unitType>
 
-  <unitType id="power" name="power"> <!--watt-->
+  <unitType id="power" name="power">
+    <!--watt-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-3"/>
   </unitType>
 
-  <unitType id="potentialDifference" name="potentialDifference"> <!--volt-->
+  <unitType id="potentialDifference" name="potentialDifference">
+    <!--volt-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-3"/>
     <dimension name="current" power="-1"/>
   </unitType>
 
-  <unitType id="capacitance" name="capacitance"> <!--farad-->
+  <unitType id="capacitance" name="capacitance">
+    <!--farad-->
     <dimension name="mass" power="-1"/>
     <dimension name="length" power="-2"/>
     <dimension name="time" power="4"/>
     <dimension name="current" power="2"/>
   </unitType>
 
-  <unitType id="resistance" name="resistance"> <!--ohm-->
+  <unitType id="resistance" name="resistance">
+    <!--ohm-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-3"/>
     <dimension name="current" power="-2"/>
   </unitType>
 
-  <unitType id="resistivity" name="resistivity"> <!--ohmMeters-->
+  <unitType id="resistivity" name="resistivity">
+    <!--ohmMeters-->
     <dimension name="mass"/>
     <dimension name="length" power="3"/>
     <dimension name="time" power="-3"/>
     <dimension name="current" power="-2"/>
   </unitType>
 
-  <unitType id="conductance" name="conductance"> <!--siemens-->
+  <unitType id="conductance" name="conductance">
+    <!--siemens-->
     <dimension name="mass" power="-1"/>
     <dimension name="length" power="-2"/>
     <dimension name="time" power="3"/>
     <dimension name="current" power="2"/>
   </unitType>
 
-  <unitType id="magneticFlux" name="magneticFlux"> <!--weber-->
+  <unitType id="magneticFlux" name="magneticFlux">
+    <!--weber-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-2"/>
     <dimension name="current" power="-1"/>
   </unitType>
 
-  <unitType id="magneticFluxDensity" name="magneticFluxDensity"> <!--tesla-->
+  <unitType id="magneticFluxDensity" name="magneticFluxDensity">
+    <!--tesla-->
     <dimension name="mass"/>
     <dimension name="time" power="-2"/>
     <dimension name="current" power="-1"/>
   </unitType>
 
-  <unitType id="inductance" name="inductance"> <!--henry-->
+  <unitType id="inductance" name="inductance">
+    <!--henry-->
     <dimension name="mass"/>
     <dimension name="length" power="2"/>
     <dimension name="time" power="-2"/>
     <dimension name="current" power="-2"/>
   </unitType>
 
-  <unitType id="illuminance" name="illuminance"> <!--lux-->
+  <unitType id="illuminance" name="illuminance">
+    <!--lux-->
     <dimension name="luminosity"/>
     <dimension name="length" power="-2"/>
   </unitType>
 
-  <unitType id="radionucleotideActivity" name="radionucleotideActivity"> <!--becquerel-->
+  <unitType id="radionucleotideActivity" name="radionucleotideActivity">
+    <!--becquerel-->
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="specificEnergy" name="specificEnergy"> <!--gray-->
+  <unitType id="specificEnergy" name="specificEnergy">
+    <!--gray-->
     <dimension name="time" power="-2"/>
     <dimension name="length" power="2"/>
   </unitType>
 
-  <unitType id="doseEquivalent" name="doseEquivalent"> <!--sievert-->
+  <unitType id="doseEquivalent" name="doseEquivalent">
+    <!--sievert-->
     <dimension name="time" power="-2"/>
     <dimension name="length" power="2"/>
   </unitType>
 
-  <unitType id="catalyticActivity" name="catalyticActivity"> <!--katal-->
+  <unitType id="catalyticActivity" name="catalyticActivity">
+    <!--katal-->
     <dimension name="time" power="-1"/>
     <dimension name="amount"/>
   </unitType>
 
-  <unitType id="pressure" name="pressure"> <!--pascal-->
+  <unitType id="pressure" name="pressure">
+    <!--pascal-->
     <dimension name="mass"/>
     <dimension name="time" power="-2"/>
     <dimension name="length" power="1"/>
   </unitType>
 
-  <unitType id="transmissivity" name="transmissivity"> <!--metersSquaredPerSecond-->
+  <unitType id="transmissivity" name="transmissivity">
+    <!--metersSquaredPerSecond-->
     <dimension name="length" power="2"/>
     <dimension name="time" power="-1"/>
   </unitType>
 
-  <unitType id="massSpecificLength" name="massSpecificLength"> <!--metersPerGram-->
+  <unitType id="massSpecificLength" name="massSpecificLength">
+    <!--metersPerGram-->
     <dimension name="length"/>
     <dimension name="mass" power="-1"/>
   </unitType>
 
-  <unitType id="massSpecificCount" name="massSpecificCount"> <!--numberPerGram-->
+  <unitType id="massSpecificCount" name="massSpecificCount">
+    <!--numberPerGram-->
     <dimension name="dimensionless"/>
     <dimension name="mass" power="-1"/>
   </unitType>
-<!-- ======================================================================= -->
-<!-- ====================== Unit Definitions =============================== -->
-<!-- ======================================================================= -->
+  <!-- ======================================================================= -->
+  <!-- ====================== Unit Definitions =============================== -->
+  <!-- ======================================================================= -->
 
-  <unit id="dimensionless" name="dimensionless" unitType="dimensionless">
+  <unit id="dimensionless" name="dimensionless" unitType="dimensionless" udunitsSynonym="">
     <description>a designation asserting the absence of an associated unit</description>
   </unit>
 
-  <unit id="second" name="second" unitType="time" abbreviation="sec" multiplierToSI="1">
+  <unit id="second" name="second" unitType="time" abbreviation="sec" multiplierToSI="1"
+    udunitsSynonym="second">
     <description>SI unit of time</description>
   </unit>
 
-  <unit id="meter" name="meter" unitType="length" abbreviation="m" multiplierToSI="1">
+  <unit id="meter" name="meter" unitType="length" abbreviation="m" multiplierToSI="1"
+    udunitsSynonym="meter">
     <description>SI unit of length</description>
   </unit>
 
-  <unit id="kilogram" name="kilogram" unitType="mass" abbreviation="kg" multiplierToSI="1">
+  <unit id="kilogram" name="kilogram" unitType="mass" abbreviation="kg" multiplierToSI="1"
+    udunitsSynonym="kilogram">
     <description>SI unit of mass</description>
   </unit>
 
-  <unit id="kelvin" name="kelvin" unitType="temperature" abbreviation="K" multiplierToSI="1">
+  <unit id="kelvin" name="kelvin" unitType="temperature" abbreviation="K" multiplierToSI="1"
+    udunitsSynonym="kelvin">
     <description>SI unit of temperature</description>
   </unit>
 
-  <unit id="coulomb" name="coulomb" unitType="charge" abbreviation="C" multiplierToSI="1">
+  <unit id="coulomb" name="coulomb" unitType="charge" abbreviation="C" multiplierToSI="1"
+    udunitsSynonym="coulomb">
     <description>SI unit of charge</description>
   </unit>
 
-  <unit id="ampere" name="ampere" unitType="current" abbreviation="A" multiplierToSI="1">
+  <unit id="ampere" name="ampere" unitType="current" abbreviation="A" multiplierToSI="1"
+    udunitsSynonym="ampere">
     <description>SI unit of electrical current</description>
   </unit>
 
-  <unit id="mole" name="mole" unitType="amount" abbreviation="mol" multiplierToSI="1">
+  <unit id="mole" name="mole" unitType="amount" abbreviation="mol" multiplierToSI="1"
+    udunitsSynonym="mole">
     <description>SI unit of substance amount</description>
   </unit>
 
-  <unit id="candela" name="candela" unitType="luminosity" abbreviation="cd" multiplierToSI="1">
-    <description>SI unit of luminosity</description>
+  <unit id="candela" name="candela" unitType="luminosity" abbreviation="cd" multiplierToSI="1"
+    udunitsSynonym="candela">
+    <description>SI base unit of luminous intensity (luminous power per unti solid angle emitted
+    by a point light source in a particular direction)</description>
   </unit>
 
-  <unit id="number" name="number" unitType="dimensionless">
-    <description>a number</description>
+  <unit id="number" name="number" unitType="dimensionless" udunitsSynonym="count">
+    <description>a quantity or amount</description>
   </unit>
 
-  <unit id="cubicMeter" name="cubicMeter" unitType="volume" multiplierToSI="1" abbreviation="m³">
+  <unit id="cubicMeter" name="cubicMeter" unitType="volume" multiplierToSI="1" abbreviation="m³"
+    deprecatedInFavorOf="meterCubed" udunitsSynonym="meter^3">
     <description>cubic meter</description>
   </unit>
 
   <!--nominal time-->
   <!--all of these date/time fields are calculated to the nearest second, excluding
   leap seconds and leap days except for nominalLeapYear.-->
-  <unit id="nominalMinute" name="nominalMinute" unitType="time" parentSI="second" multiplierToSI="60">
-    <description>one minute excluding leap seconds, 60 seconds</description>
+  <unit id="nominalMinute" name="nominalMinute" unitType="time" parentSI="second"
+    multiplierToSI="60" udunitsSynonym="minute">
+    <description>one minute of time excluding leap seconds, 60 seconds</description>
   </unit>
-  <unit id="nominalHour" name="nominalHour" unitType="time" parentSI="second" multiplierToSI="3600">
+  <unit id="nominalHour" name="nominalHour" unitType="time" parentSI="second" multiplierToSI="3600"
+    udunitsSynonym="hour">
     <description>one hour excluding leap seconds, 3600 seconds</description>
   </unit>
-  <unit id="nominalDay" name="nominalDay" unitType="time" parentSI="second" multiplierToSI="86400">
+  <unit id="nominalDay" name="nominalDay" unitType="time" parentSI="second" multiplierToSI="86400"
+    udunitsSynonym="day">
     <description>one day excluding leap seconds, 86400 seconds</description>
   </unit>
-  <unit id="nominalWeek" name="nominalWeek" unitType="time" parentSI="second" multiplierToSI="604800">
+  <unit id="nominalWeek" name="nominalWeek" unitType="time" parentSI="second"
+    multiplierToSI="604800" udunitsSynonym="week">
     <description>one day excluding leap seconds, 604800 seconds</description>
   </unit>
-  <unit id="nominalYear" name="nominalYear" unitType="time" parentSI="second" multiplierToSI="31536000">
+  <unit id="nominalYear" name="nominalYear" unitType="time" parentSI="second"
+    multiplierToSI="31536000" udunitsSynonym="common_year">
     <description>one year excluding leap seconds and leap days, 31536000 seconds</description>
   </unit>
-  <unit id="nominalLeapYear" name="nominalLeapYear" unitType="time" parentSI="second" multiplierToSI="31622400">
+  <unit id="nominalLeapYear" name="nominalLeapYear" unitType="time" parentSI="second"
+    multiplierToSI="31622400" udunitsSynonym="leap_year">
     <description>one 366 day year excluding leap seconds, 31622400 seconds</description>
   </unit>
 
   <!--mass-->
-  <unit id="nanogram" name="nanogram" unitType="mass" parentSI="kilogram" multiplierToSI="0.000000000001" abbreviation="ng">
+  <unit id="nanogram" name="nanogram" unitType="mass" parentSI="kilogram"
+    multiplierToSI="0.000000000001" abbreviation="ng" udunitsSynonym="nanogram">
     <description>0.000000000001 kg</description>
   </unit>
-  <unit id="microgram" name="microgram" unitType="mass" parentSI="kilogram" multiplierToSI="0.000000001" abbreviation="μg">
+  <unit id="microgram" name="microgram" unitType="mass" parentSI="kilogram"
+    multiplierToSI="0.000000001" abbreviation="μg" udunitsSynonym="microgram">
     <description>0.000000001 kg</description>
   </unit>
-  <unit id="milligram" name="milligram" unitType="mass" parentSI="kilogram" multiplierToSI="0.000001" abbreviation="mg">
+  <unit id="milligram" name="milligram" unitType="mass" parentSI="kilogram"
+    multiplierToSI="0.000001" abbreviation="mg" udunitsSynonym="milligram">
     <description>0.000001 kg</description>
   </unit>
-  <unit id="centigram" name="centigram" unitType="mass" parentSI="kilogram" multiplierToSI="0.00001" abbreviation="cg">
+  <unit id="centigram" name="centigram" unitType="mass" parentSI="kilogram" multiplierToSI="0.00001"
+    abbreviation="cg" udunitsSynonym="centigram">
     <description>0.00001 kg</description>
   </unit>
-   <unit id="decigram" name="decigram" unitType="mass" parentSI="kilogram" multiplierToSI="0.0001" abbreviation="dg">
+  <unit id="decigram" name="decigram" unitType="mass" parentSI="kilogram" multiplierToSI="0.0001"
+    abbreviation="dg" udunitsSynonym="decigram">
     <description>0.0001 kg</description>
   </unit>
-  <unit id="gram" name="gram" unitType="mass" parentSI="kilogram" multiplierToSI="0.001" abbreviation="g">
+  <unit id="gram" name="gram" unitType="mass" parentSI="kilogram" multiplierToSI="0.001"
+    abbreviation="g" udunitsSynonym="gram">
     <description>0.001 kg</description>
   </unit>
-  <unit id="dekagram" name="dekagram" unitType="mass" parentSI="kilogram" multiplierToSI="0.01" abbreviation="dag">
+  <unit id="dekagram" name="dekagram" unitType="mass" parentSI="kilogram" multiplierToSI="0.01"
+    abbreviation="dag" udunitsSynonym="dekagram">
     <description>.01 kg</description>
   </unit>
-  <unit id="hectogram" name="hectogram" unitType="mass" parentSI="kilogram" multiplierToSI="0.1" abbreviation="hg">
+  <unit id="hectogram" name="hectogram" unitType="mass" parentSI="kilogram" multiplierToSI="0.1"
+    abbreviation="hg" udunitsSynonym="hectogram">
     <description>.1 kg</description>
   </unit>
-  <unit id="megagram" name="megagram" unitType="mass" parentSI="kilogram" multiplierToSI="1000" abbreviation="Mg">
+  <unit id="megagram" name="megagram" unitType="mass" parentSI="kilogram" multiplierToSI="1000"
+    abbreviation="Mg" udunitsSynonym="megagram">
     <description>1000 kg</description>
   </unit>
 
-  <unit id="tonne" name="tonne" unitType="mass" parentSI="kilogram" multiplierToSI="1000" abbreviation="T">
-    <description>metric ton or tonne</description>
+  <unit id="tonne" name="tonne" unitType="mass" parentSI="kilogram" multiplierToSI="1000"
+    abbreviation="T" udunitsSynonym="metric_ton">
+    <description>unit of mass equal to 1,000 kilograms, equivalent to approximately 2,204.6 
+      pounds,1.102 short tons (US) or 0.984 long tons (imperial). 
+      Not part of the SI, but accepted for use with SI units and prefixes</description>
   </unit>
 
-  <unit id="pound" name="pound" parentSI="kilogram" abbreviation="lbs" multiplierToSI="0.4536">
-    <description>1 pound in the Avoirdupois (commerce) scale</description>
+  <unit id="pound" name="pound" parentSI="kilogram" abbreviation="lbs" multiplierToSI="0.4536"
+    udunitsSynonym="avoirdupois_pound">
+    <description>1 pound (symbol lb) in the Avoirdupois (commerce) scale, and defined 
+      as exactly 0.45359237 kg. Also equal to 16 avoirdupois ounces and to 7,000 grains.</description>
   </unit>
-  <unit id="ton" name="ton" parentSI="kilogram" abbreviation="ton" multiplierToSI="907.1999">
+  <unit id="ton" name="ton" parentSI="kilogram" abbreviation="ton" multiplierToSI="907.1999"
+    udunitsSynonym="short_ton">
     <description>standard US (short) ton = 2000 lbs</description>
   </unit>
 
   <!--temp-->
-  <unit id="celsius" name="celsius" parentSI="kelvin" multiplierToSI="1" constantToSI="273.18" abbreviation="C">
+  <unit id="celsius" name="celsius" parentSI="kelvin" multiplierToSI="1" constantToSI="273.18"
+    abbreviation="C" udunitsSynonym="celsius">
     <description>A common unit of temperature</description>
   </unit>
 
-  <unit id="fahrenheit" name="fahrenheit" parentSI="kelvin" abbreviation="F" multiplierToSI="0.556" constantToSI="255.402">
-    <description>An obsolescent unit of temperature still used in popular meteorology</description>
+  <unit id="fahrenheit" name="fahrenheit" parentSI="kelvin" abbreviation="F" multiplierToSI="0.556"
+    constantToSI="255.402" udunitsSynonym="fahrenheit">
+    <description>unit for temperature on the scale in which water freezes at 32 and boils 
+      at 212 under standard conditions.</description>
   </unit>
 
   <!--length-->
-  <unit id="nanometer" name="nanometer" parentSI="meter" multiplierToSI="0.000000001" abbreviation="nm">
+  <unit id="nanometer" name="nanometer" parentSI="meter" multiplierToSI="0.000000001"
+    abbreviation="nm" udunitsSynonym="nanometer">
     <description>.000000001 meters</description>
   </unit>
-  <unit id="micrometer" name="micrometer" parentSI="meter" multiplierToSI="0.000001" abbreviation="μm">
+  <unit id="micrometer" name="micrometer" parentSI="meter" multiplierToSI="0.000001"
+    abbreviation="μm" udunitsSynonym="micrometer">
     <description>.000001 meters</description>
   </unit>
-  <unit id="micron" name="micron" parentSI="meter" multiplierToSI="0.000001" abbreviation="μ">
+  <unit id="micron" name="micron" parentSI="meter" multiplierToSI="0.000001" abbreviation="μ"
+    deprecatedInFavorOf="micrometer" udunitsSynonym="micrometer">
     <description>.000001 meters</description>
   </unit>
-  <unit id="millimeter" name="millimeter" parentSI="meter" multiplierToSI="0.001" abbreviation="mm">
+  <unit id="millimeter" name="millimeter" parentSI="meter" multiplierToSI="0.001" abbreviation="mm"
+    udunitsSynonym="millimeter">
     <description>.001 meters</description>
   </unit>
-  <unit id="centimeter" name="centimeter" parentSI="meter" multiplierToSI="0.01" abbreviation="cm">
+  <unit id="centimeter" name="centimeter" parentSI="meter" multiplierToSI="0.01" abbreviation="cm"
+    udunitsSynonym="centimeter">
     <description>.01 meters</description>
   </unit>
-  <unit id="decimeter" name="decimeter" parentSI="meter" multiplierToSI="0.1" abbreviation="dm">
+  <unit id="decimeter" name="decimeter" parentSI="meter" multiplierToSI="0.1" abbreviation="dm"
+    udunitsSynonym="decimeter">
     <description>.1 meters</description>
   </unit>
-  <unit id="dekameter" name="dekameter" parentSI="meter" multiplierToSI="10" abbreviation="dam">
+  <unit id="dekameter" name="dekameter" parentSI="meter" multiplierToSI="10" abbreviation="dam"
+    udunitsSynonym="dekameter">
     <description>10 meters</description>
   </unit>
-  <unit id="hectometer" name="hectometer" parentSI="meter" multiplierToSI="100" abbreviation="hm">
+  <unit id="hectometer" name="hectometer" parentSI="meter" multiplierToSI="100" abbreviation="hm"
+    udunitsSynonym="hectometer">
     <description>100 meters</description>
   </unit>
-  <unit id="kilometer" name="kilometer" parentSI="meter" multiplierToSI="1000" abbreviation="km">
+  <unit id="kilometer" name="kilometer" parentSI="meter" multiplierToSI="1000" abbreviation="km"
+    udunitsSynonym="kilometer">
     <description>1000 meters</description>
   </unit>
-  <unit id="megameter" name="megameter" parentSI="meter" multiplierToSI="1000000" abbreviation="Mm">
+  <unit id="megameter" name="megameter" parentSI="meter" multiplierToSI="1000000" abbreviation="Mm"
+    udunitsSynonym="megameter">
     <description>1000000 meters</description>
   </unit>
-  <unit id="angstrom" name="angstrom" parentSI="meter" multiplierToSI="0.0000000001" abbreviation="Å">
+  <unit id="angstrom" name="angstrom" parentSI="meter" multiplierToSI="0.0000000001"
+    abbreviation="Å" udunitsSynonym="angstrom">
     <description>1/10000000000 meter</description>
   </unit>
 
-  <unit id="inch" name="inch" parentSI="meter" abbreviation="in" multiplierToSI="0.0254">
-    <description>An imperial measure of length</description>
+  <unit id="inch" name="inch" parentSI="meter" abbreviation="in" multiplierToSI="0.0254"
+    udunitsSynonym="international_inch">
+    <description>unit of length in the (British) imperial and United States systems 
+      usually understood as 1/12 f a foot.</description>
   </unit>
-  <unit id="Foot_US" name="Foot_US" parentSI="meter" abbreviation="usft" multiplierToSI="0.3048">
+  <unit id="Foot_US" name="Foot_US" parentSI="meter" abbreviation="usft" multiplierToSI="0.3048006"
+    udunitsSynonym="US_survey_foot">
     <description>12 inches</description>
   </unit>
-  <unit id="foot" name="foot" parentSI="meter" abbreviation="ft" multiplierToSI="0.3048">
+  <unit id="foot" name="foot" parentSI="meter" abbreviation="ft" multiplierToSI="0.3048"
+    udunitsSynonym="international_foot">
     <description>12 inches</description>
   </unit>
-  <unit id="Foot_Gold_Coast" name="Foot_Gold_Coast" parentSI="meter" abbreviation="gcft" multiplierToSI="0.3047997">
+  <unit id="Foot_Gold_Coast" name="Foot_Gold_Coast" parentSI="meter" abbreviation="gcft"
+    multiplierToSI="0.3047997" udunitsSynonym="">
     <description>12 inches</description>
   </unit>
-  <unit id="fathom" name="fathom" parentSI="meter" multiplierToSI="1.8288">
+  <unit id="fathom" name="fathom" parentSI="meter" multiplierToSI="1.8288" udunitsSynonym="fathom">
     <description>6 feet</description>
   </unit>
-  <unit id="nauticalMile" name="nauticalMile" parentSI="meter" multiplierToSI="1852">
-    <description>nautical mile</description>
+  <unit id="nauticalMile" name="nauticalMile" parentSI="meter" multiplierToSI="1852"
+    udunitsSynonym="nautical_mile">
+    <description>defined as exactly 1,852 meters (6,076.1 ft; 1.1508 mi). Historically, 
+      defined as one minute of latitude.</description>
   </unit>
-  <unit id="yard" name="yard" parentSI="meter" abbreviation="yard" multiplierToSI="0.9144">
+  <unit id="yard" name="yard" parentSI="meter" abbreviation="yard" multiplierToSI="0.9144"
+    udunitsSynonym="international_yard">
     <description>3 feet</description>
   </unit>
-  <unit id="Yard_Indian" name="Yard_Indian" parentSI="meter" multiplierToSI="0.914398530744440774">
-    <description>This is an ESRI unit and the multiplier comes from ESRI.  It
-    may not be accurate.</description>
+  <unit id="Yard_Indian" name="Yard_Indian" parentSI="meter" multiplierToSI="0.914398530744440774"
+    udunitsSynonym="">
+    <description>This is an ESRI unit and the multiplier comes from ESRI. It may not be
+      accurate.</description>
   </unit>
-  <unit id="Link_Clarke" name="Link_Clarke" parentSI="meter" multiplierToSI="0.2011661949">
-    <description>This is an ESRI unit and the multiplier comes from ESRI.  It
-    may not be accurate.</description>
+  <unit id="Link_Clarke" name="Link_Clarke" parentSI="meter" multiplierToSI="0.2011661949"
+    udunitsSynonym="">
+    <description>This is an ESRI unit and the multiplier comes from ESRI. It may not be
+      accurate.</description>
   </unit>
-  <unit id="Yard_Sears" name="Yard_Sears" parentSI="meter" multiplierToSI="0.91439841461602867">
-    <description>This is an ESRI unit and the multiplier comes from ESRI.  It
-    may not be accurate.</description>
+  <unit id="Yard_Sears" name="Yard_Sears" parentSI="meter" multiplierToSI="0.91439841461602867"
+    deprecatedInFavorOf="yard" udunitsSynonym="">
+    <description>This is an ESRI unit and the multiplier comes from ESRI. It may not be
+      accurate.</description>
   </unit>
-  <unit id="mile" name="mile" parentSI="meter" abbreviation="mile" multiplierToSI="1609.344">
+  <unit id="mile" name="mile" parentSI="meter" abbreviation="mile" multiplierToSI="1609.344"
+    udunitsSynonym="international_mile">
     <description>5280 ft or 1609.344 meters</description>
   </unit>
 
   <!--seconds-->
-  <unit id="nanosecond" name="nanosecond" parentSI="second" multiplierToSI="0.000000001" abbreviation="nsec">
+  <unit id="nanosecond" name="nanosecond" parentSI="second" multiplierToSI="0.000000001"
+    abbreviation="nsec" udunitsSynonym="nanosecond">
     <description>1/1000000 of a second</description>
   </unit>
-  <unit id="microsecond" name="microsecond" parentSI="second" multiplierToSI="0.000001" abbreviation="μsec">
+  <unit id="microsecond" name="microsecond" parentSI="second" multiplierToSI="0.000001"
+    abbreviation="μsec" udunitsSynonym="microsecond">
     <description>1/100000 of a second</description>
   </unit>
-  <unit id="millisecond" name="millisecond" parentSI="second" multiplierToSI="0.001" abbreviation="msec">
+  <unit id="millisecond" name="millisecond" parentSI="second" multiplierToSI="0.001"
+    abbreviation="msec" udunitsSynonym="millisecond">
     <description>1/1000 of a second</description>
   </unit>
-  <unit id="centisecond" name="centisecond" parentSI="second" multiplierToSI="0.01" abbreviation="csec">
+  <unit id="centisecond" name="centisecond" parentSI="second" multiplierToSI="0.01"
+    abbreviation="csec" udunitsSynonym="centisecond">
     <description>1/100 of a second</description>
   </unit>
-  <unit id="decisecond" name="decisecond" parentSI="second" multiplierToSI="0.1" abbreviation="dsec">
+  <unit id="decisecond" name="decisecond" parentSI="second" multiplierToSI="0.1" abbreviation="dsec"
+    udunitsSynonym="decisecond">
     <description>1/10 of a second</description>
   </unit>
-  <unit id="dekasecond" name="dekasecond" parentSI="second" multiplierToSI="10" abbreviation="dasec">
+  <unit id="dekasecond" name="dekasecond" parentSI="second" multiplierToSI="10" abbreviation="dasec"
+    udunitsSynonym="dekasecond">
     <description>10 seconds</description>
   </unit>
-  <unit id="hectosecond" name="hectosecond" parentSI="second" multiplierToSI="100" abbreviation="hsec">
+  <unit id="hectosecond" name="hectosecond" parentSI="second" multiplierToSI="100"
+    abbreviation="hsec" udunitsSynonym="hectosecond">
     <description>100 seconds</description>
   </unit>
-  <unit id="kilosecond" name="kilosecond" parentSI="second" multiplierToSI="1000" abbreviation="ksec">
+  <unit id="kilosecond" name="kilosecond" parentSI="second" multiplierToSI="1000"
+    abbreviation="ksec" udunitsSynonym="kilosecond">
     <description>1000 seconds</description>
   </unit>
-  <unit id="megasecond" name="megasecond" parentSI="second" multiplierToSI="1000000" abbreviation="Msec">
+  <unit id="megasecond" name="megasecond" parentSI="second" multiplierToSI="1000000"
+    abbreviation="Msec" udunitsSynonym="megasecond">
     <description>1000000 seconds</description>
   </unit>
-  <unit id="minute" name="minute" parentSI="second" multiplierToSI="60" abbreviation="min">
+  <unit id="minute" name="minute" parentSI="second" multiplierToSI="60" abbreviation="min"
+    udunitsSynonym="minute">
     <description>60 seconds</description>
   </unit>
-  <unit id="hour" name="hour" parentSI="second" multiplierToSI="3600" abbreviation="hr">
+  <unit id="hour" name="hour" parentSI="second" multiplierToSI="3600" abbreviation="hr"
+    udunitsSynonym="hour">
     <description>3600 seconds</description>
   </unit>
 
   <!--volume-->
-  <unit id="kiloliter" name="kiloliter" unitType="volume" parentSI="cubicMeter" multiplierToSI="1" abbreviation="kL">
+  <unit id="kiloliter" name="kiloliter" unitType="volume" parentSI="cubicMeter" multiplierToSI="1"
+    abbreviation="kL" udunitsSynonym="kiloliter">
     <description>1 cubic meter</description>
   </unit>
-  <unit id="microliter" name="microliter" unitType="volume" parentSI="cubicMeter" multiplierToSI="0.000000001" abbreviation="μl">
+  <unit id="microliter" name="microliter" unitType="volume" parentSI="cubicMeter"
+    multiplierToSI="0.000000001" abbreviation="μl" udunitsSynonym="microliter">
     <description>1/1000000 of a liter</description>
   </unit>
-  <unit id="milliliter" name="milliliter" unitType="volume" parentSI="cubicMeter" multiplierToSI="0.000001" abbreviation="ml">
+  <unit id="milliliter" name="milliliter" unitType="volume" parentSI="cubicMeter"
+    multiplierToSI="0.000001" abbreviation="ml" udunitsSynonym="milliliter">
     <description>1/1000 of a liter</description>
   </unit>
-  <unit id="liter" name="liter" unitType="volume" parentSI="cubicMeter" multiplierToSI="0.001" abbreviation="L">
+  <unit id="liter" name="liter" unitType="volume" parentSI="cubicMeter" multiplierToSI="0.001"
+    abbreviation="L" udunitsSynonym="liter">
     <description>1000 cm^3</description>
   </unit>
 
-  <unit id="gallon" name="gallon" parentSI="liter" multiplierToSI="3.785412" abbreviation="gal">
+  <unit id="gallon" name="gallon" parentSI="liter" multiplierToSI="3.785412" abbreviation="gal"
+    udunitsSynonym="US_liquid_gallon">
     <description>US liquid gallon</description>
   </unit>
-  <unit id="quart" name="quart" parentSI="liter" multiplierToSI="0.946353" abbreviation="qt">
+  <unit id="quart" name="quart" parentSI="liter" multiplierToSI="0.946353" abbreviation="qt"
+    udunitsSynonym="US_liquid_quart">
     <description>US liquid quart</description>
   </unit>
 
-  <unit id="bushel" name="bushel" unitType="volume" parentSI="liter" multiplierToSI="0.035239" abbreviation="b">
+  <unit id="bushel" name="bushel" unitType="volume" parentSI="liter" multiplierToSI="35.23907"
+    abbreviation="b" udunitsSynonym="bushel">
     <description>1 bushel = 35.23907 liters</description>
   </unit>
 
-  <unit id="cubicInch" name="cubicInch" parentSI="liter" unitType="volume" multiplierToSI="0.000016387064" abbreviation="in³">
+  <unit id="cubicInch" name="cubicInch" parentSI="liter" unitType="volume"
+    multiplierToSI="0.01638706" abbreviation="in³" deprecatedInFavorOf="inchCubed"
+    udunitsSynonym="international_inch^3">
     <description>cubic inch</description>
   </unit>
 
-  <unit id="pint" name="pint" parentSI="liter" abbreviation="pint" multiplierToSI="0.473176">
+  <unit id="pint" name="pint" parentSI="liter" abbreviation="pint" multiplierToSI="0.473176"
+    udunitsSynonym="US_liquid_pint">
     <description>US liquid pint</description>
   </unit>
 
+  <unit id="meterCubed" name="meterCubed" unitType="volume" parentSI="meterCubed" multiplierToSI="1"
+    abbreviation="m³" udunitsSynonym="meter^3">
+    <description>cubic meter</description>
+  </unit>
+  <unit id="centimeterCubed" name="centimeterCubed" unitType="volume" parentSI="meterCubed"
+    multiplierToSI="0.000001" abbreviation="cm³" udunitsSynonym="centimeter^3">
+    <description>cubic meter</description>
+  </unit>
+  <unit id="inchCubed" name="inchCubed" unitType="volume" parentSI="liter"
+    multiplierToSI="0.01638706" abbreviation="in³" udunitsSynonym="international_inch^3">
+    <description>micromoles per square meter per second</description>
+  </unit>
 
   <!--angles-->
-  <unit id="radian" name="radian" unitType="angle" multiplierToSI="1" abbreviation="rad">
+  <unit id="radian" name="radian" unitType="angle" multiplierToSI="1" abbreviation="rad"
+    udunitsSynonym="radian">
     <description>2 pi radians comprise a unit circle.</description>
   </unit>
-  <unit id="degree" name="degree" unitType="angle" parentSI="radian" multiplierToSI="0.0174532924" abbreviation="º">
+  <unit id="degree" name="degree" unitType="angle" parentSI="radian" multiplierToSI="0.0174532924"
+    abbreviation="º" udunitsSynonym="arc_degree">
     <description>360 degrees comprise a unit circle</description>
   </unit>
-  <unit id="grad" name="grad" unitType="angle" parentSI="radian" multiplierToSI="0.015707" abbreviation="grad">
+  <unit id="grad" name="grad" unitType="angle" parentSI="radian" multiplierToSI="0.015707"
+    abbreviation="grad" udunitsSynonym="">
     <description>a plane angle equivalent to 1/400 of a full circle</description>
+  </unit>
+  <unit id="steradian" name="steradian" unitType="angle" multiplierToSI="1" abbreviation="sr"
+    udunitsSynonym="steradian">
+    <description>standard unit of solid angle measure, it is the solid angle which cuts out an area
+      on a sphere that is the square of the sphere's radius; as a ratio of two areas, it has no
+      dimension</description>
   </unit>
 
   <!--frequency-->
-  <unit id="megahertz" name="megahertz" unitType="frequency" parentSI="hertz" multiplierToSI="1000000" abbreviation="MHz">
+  <unit id="megahertz" name="megahertz" unitType="frequency" parentSI="hertz"
+    multiplierToSI="1000000" abbreviation="MHz" udunitsSynonym="megahertz">
     <description>megahertz</description>
   </unit>
-  <unit id="kilohertz" name="kilohertz" unitType="frequency" parentSI="hertz" multiplierToSI="1000" abbreviation="KHz">
+  <unit id="kilohertz" name="kilohertz" unitType="frequency" parentSI="hertz" multiplierToSI="1000"
+    abbreviation="KHz" udunitsSynonym="kilohertz">
     <description>kilohertz</description>
   </unit>
-  <unit id="hertz" name="hertz" unitType="frequency" multiplierToSI="1" abbreviation="Hz">
-    <description>hertz</description>
+  <unit id="hertz" name="hertz" unitType="frequency" multiplierToSI="1" abbreviation="Hz"
+    udunitsSynonym="hertz">
+    <description>derived unit of frequency in the SI, defined as one cycle per second</description>
   </unit>
-  <unit id="millihertz" name="millihertz"  parentSI="hertz" unitType="frequency" multiplierToSI="0.000001" abbreviation="mHz">
+  <unit id="millihertz" name="millihertz" parentSI="hertz" unitType="frequency"
+    multiplierToSI="0.001" abbreviation="mHz" udunitsSynonym="millihertz">
     <description>millihertz</description>
   </unit>
 
   <!--force -->
-  <unit id="newton" name="newton" unitType="force" multiplierToSI="1" abbreviation="N">
+  <unit id="newton" name="newton" unitType="force" multiplierToSI="1" abbreviation="N"
+    udunitsSynonym="newton">
     <description>newton</description>
   </unit>
 
   <!--energy-->
-  <unit id="joule" name="joule" unitType="energy" multiplierToSI="1" abbreviation="J">
+  <unit id="joule" name="joule" unitType="energy" multiplierToSI="1" abbreviation="J"
+    udunitsSynonym="joule">
     <description>joule = N*m</description>
   </unit>
-  <unit id="calorie" name="calorie" unitType="energy" parentSI="joule" multiplierToSI="4.1868" abbreviation="cal">
-    <description>1 cal = 4.1868 J</description>
+  <unit id="calorie" name="calorie" unitType="energy" parentSI="joule" multiplierToSI="4.1868"
+    abbreviation="cal" udunitsSynonym="IT_calorie">
+    <description>unit of energy: amount of energy to raise the temperature of one gram of water 
+      by one degree Celsius at a pressure of one atmosphere. cal = 4.1868 J</description>
   </unit>
-  <unit id="britishThermalUnit" name="britishThermalUnit" unitType="energy" parentSI="joule" multiplierToSI="1055.0559" abbreviation="btu">
-    <description>1 btu = 1055.0559 J</description>
+  <unit id="britishThermalUnit" name="britishThermalUnit" unitType="energy" parentSI="joule"
+    multiplierToSI="1055.0559" abbreviation="btu" udunitsSynonym="IT_Btu">
+    <description>an energy unit: 1 btu = 1055.0559 J</description>
   </unit>
-  <unit id="footPound" name="footPound" unitType="energy" parentSI="joule" multiplierToSI="1.355818">
+  <unit id="footPound" name="footPound" unitType="energy" parentSI="joule" multiplierToSI="1.355818"
+    udunitsSynonym="international_foot pound_force">
     <description>1 ft-lbs = 1.355818 J</description>
   </unit>
-
+  <unit id="langley" name="langley" abbreviation="Ly" 
+    unitType="arealEnergyDensity" parentSI="joulePerMeterSquared" multiplierToSI="41840" constantToSI="0"
+    udunitsSynonym="langley">
+    <description>unit of energy density = 41840 joule/m^2, = 1 calorie/cm^2</description>
+  </unit>
   <!--luminosity-->
-  <unit id="lumen" name="lumen" unitType="luminosity" multiplierToSI="1" abbreviation="lm">
-    <description>lumen</description>
+  <unit id="lumen" name="lumen" unitType="luminosity" multiplierToSI="1" abbreviation="lm"
+    udunitsSynonym="lumen">
+    <description>SI unit for the total quantity of visible light in a defined beam or angle.
+      1 lumen/m^2 = 1 lux. 1 lumen = 1 candela * steradian </description>
   </unit>
 
   <!--illuminance-->
-  <unit id="lux" name="lux" unitType="illuminance" multiplierToSI="1" abbreviation="lx">
-    <description>lux</description>
+  <unit id="lux" name="lux" unitType="illuminance" multiplierToSI="1" abbreviation="lx"
+    udunitsSynonym="lux">
+    <description>SI derived unit for illuminance, or luminous flux per unit area. 1 lx = 1 lm/m^2 = 1 cd * sr/m^2</description>
   </unit>
 
   <!--radionucleotide Activity-->
-  <unit id="becquerel" name="becquerel" unitType="radionucleotideActivity" multiplierToSI="1" abbreviation="Bq">
-    <description>becquerel</description>
+  <unit id="becquerel" name="becquerel" unitType="radionucleotideActivity" multiplierToSI="1"
+    abbreviation="Bq" udunitsSynonym="becquerel">
+    <description>SI derived unit of radioactivity. the activity of a quantity of radioactive material in which 
+      one nucleus decays per second, and equivalent to an inverse second, s^-1.</description>
   </unit>
 
   <!--specific energy-->
-  <unit id="gray" name="gray" unitType="specificEnergy" multiplierToSI="1" abbreviation="Gy">
-    <description>gray</description>
+  <unit id="gray" name="gray" unitType="specificEnergy" multiplierToSI="1" abbreviation="Gy"
+    udunitsSynonym="gray">
+    <description>SI derived unit of ionizing radiation, defined as the absorption of one joule of 
+      radiation energy per kilogram of matter (= 1 J/kg)</description>
   </unit>
 
   <!--dose equivalent-->
-  <unit id="sievert" name="sievert" unitType="doseEquivalent" multiplierToSI="1" abbreviation="Sv">
-    <description>sievert</description>
+  <unit id="sievert" name="sievert" unitType="doseEquivalent" multiplierToSI="1" abbreviation="Sv"
+    udunitsSynonym="sievert">
+    <description>SI derived unit of ionizing radiation dose (health effect of low levels of ionizing 
+      radiation on humans). 1 Sv =  100 rem (rem is an older, non-SI unit)</description>
   </unit>
 
   <!--catalytic activity-->
-  <unit id="katal" name="katal" unitType="catalyticActivity" multiplierToSI="1" abbreviation="kat">
-    <description>katal</description>
+  <unit id="katal" name="katal" unitType="catalyticActivity" multiplierToSI="1" abbreviation="kat"
+    udunitsSynonym="katal">
+    <description>derived SI unit for quantifying enzymatic activity.A property of the catalyst 
+      (not rate of reaction), expressed in moles/second.</description>
   </unit>
 
   <!--inductance-->
-  <unit id="henry" name="henry" unitType="inductance" multiplierToSI="1" abbreviation="H">
-    <description>henry</description>
+  <unit id="henry" name="henry" unitType="inductance" multiplierToSI="1" abbreviation="H"
+    udunitsSynonym="henry">
+    <description>SI derived unit for inductance; in SI base units: kg * m^2 * s^-2 * A^-2</description>
   </unit>
 
   <!--power-->
-  <unit id="megawatt" name="megawatt" unitType="power" parentSI="watt" multiplierToSI="1000000" abbreviation="MW">
-    <description>megawatt</description>
+  <unit id="megawatt" name="megawatt" unitType="power" parentSI="watt" multiplierToSI="1000000"
+    abbreviation="MW" udunitsSynonym="megawatt">
+    <description>unit of power, to quantify rate of energy transfer. 1 W = J/s</description>
   </unit>
-  <unit id="kilowatt" name="kilowatt" unitType="power" parentSI="watt" multiplierToSI="1000" abbreviation="kW">
-    <description>kilowatt</description>
+  <unit id="kilowatt" name="kilowatt" unitType="power" parentSI="watt" multiplierToSI="1000"
+    abbreviation="kW" udunitsSynonym="kilowatt">
+    <description>unit of power, to quantify rate of energy transfer. 1 W = J/s</description>
   </unit>
-  <unit id="watt" name="watt" unitType="power" multiplierToSI="1" abbreviation="W">
-    <description>watt = J/s</description>
+  <unit id="watt" name="watt" unitType="power" multiplierToSI="1" abbreviation="W"
+    udunitsSynonym="watt">
+    <description>unit of power, to quantify rate of energy transfer. 1 W = J/s</description>
   </unit>
-  <unit id="milliwatt" name="milliwatt" unitType="power" parentSI="watt" multiplierToSI="0.001" abbreviation="mW">
-    <description>milliwatt</description>
+  <unit id="milliwatt" name="milliwatt" unitType="power" parentSI="watt" multiplierToSI="0.001"
+    abbreviation="mW" udunitsSynonym="milliwatt">
+    <description>unit of power, to quantify rate of energy transfer. 1 W = J/s</description>
   </unit>
 
   <!--potiential difference-->
-  <unit id="megavolt" name="megavolt" unitType="potentialDifference" parentSI="volt" multiplierToSI="1000000" abbreviation="MV">
-    <description>megavolt</description>
+  <unit id="megavolt" name="megavolt" unitType="potentialDifference" parentSI="volt"
+    multiplierToSI="1000000" abbreviation="MV" udunitsSynonym="megavolt">
+    <description>Derived unit for electric potential, electric potential difference, 
+      and electromotive force. 1 V = kg * m^2 * s^-3 * A^-1</description>
   </unit>
-  <unit id="kilovolt" name="kilovolt" unitType="potentialDifference" parentSI="volt" multiplierToSI="1000" abbreviation="kV">
-    <description>kilovolt</description>
+  <unit id="kilovolt" name="kilovolt" unitType="potentialDifference" parentSI="volt"
+    multiplierToSI="1000" abbreviation="kV" udunitsSynonym="kilovolt">
+    <description>Derived unit for electric potential, electric potential difference, 
+      and electromotive force. 1 V = kg * m^2 * s^-3 * A^-1</description>
   </unit>
-  <unit id="volt" name="volt" unitType="potentialDifference" multiplierToSI="1" abbreviation="V">
-    <description>volt</description>
+  <unit id="volt" name="volt" unitType="potentialDifference" multiplierToSI="1" abbreviation="V"
+    udunitsSynonym="volt">
+    <description>Derived unit for electric potential, electric potential difference, 
+      and electromotive force. 1 V = kg * m^2 * s^-3 * A^-1</description>
   </unit>
-  <unit id="millivolt" name="millivolt" unitType="potentialDifference" parentSI="volt" multiplierToSI="0.001" abbreviation="mV">
-    <description>millivolt</description>
+  <unit id="millivolt" name="millivolt" unitType="potentialDifference" parentSI="volt"
+    multiplierToSI="0.001" abbreviation="mV" udunitsSynonym="millivolt">
+    <description>Derived unit for electric potential, electric potential difference, 
+      and electromotive force. 1 V = kg * m^2 * s^-3 * A^-1</description>
   </unit>
 
   <!--capacitance-->
-  <unit id="farad" name="farad" unitType="capacitance" multiplierToSI="1" abbreviation="F">
-    <description>farad</description>
+  <unit id="farad" name="farad" unitType="capacitance" multiplierToSI="1" abbreviation="F"
+    udunitsSynonym="farad">
+    <description>SI derived unit of electrical capacitance, the ability of a body to store an 
+      electrical charge. 1 F = s^4 * A^2 *m^-2 * kg^-1</description>
   </unit>
 
   <!--resistance-->
-  <unit id="ohm" name="ohm" unitType="resistance" multiplierToSI="1" abbreviation="Ω">
-    <description>ohm</description>
+  <unit id="ohm" name="ohm" unitType="resistance" multiplierToSI="1" abbreviation="Ω"
+    udunitsSynonym="ohm">
+    <description>an electrical resistance between two points of a conductor when a constant potential 
+      difference of one volt, 
+      applied to these points, produces in the conductor a current of one ampere</description>
   </unit>
 
   <!--resistivity-->
-  <unit id="ohmMeter" name="ohmMeter" unitType="resistivity" multiplierToSI="1" abbreviation="Ωm">
-    <description>ohm meters</description>
+  <unit id="ohmMeter" name="ohmMeter" unitType="resistivity" multiplierToSI="1" abbreviation="Ωm"
+    udunitsSynonym="ohm meter">
+    <description>SI unit of electrical resistivity (fundamental property that quantifies how strongly a material 
+      opposes the flow of electric current). reciprocal of electrical conductivity. </description>
   </unit>
 
+  <!--conductivity-->
+  <unit id="siemensPerMeter" name="siemensPerMeter" unitType="" parentSI="siemensPerMeter"
+    multiplierToSI="1" abbreviation="S/m" udunitsSynonym="siemens/meter">
+    <description>SI unit for conductivity, measure of a material's ability to conduct an 
+      electric current.</description>
+  </unit>
+  <unit id="siemensPerCentimeter" name="siemensPerCentimeter" unitType="" parentSI="siemensPerMeter"
+    multiplierToSI=".01" abbreviation="S/cm" udunitsSynonym="siemens/centimeter">
+    <description>SI unit for conductivity, measure of a material's ability to conduct an 
+      electric current.</description>
+  </unit>
+  
   <!--conductance-->
-  <unit id="siemen" name="siemen" unitType="conductance" multiplierToSI="1" abbreviation="S">
-    <description>siemen</description>
+  <unit id="siemen" name="siemen" unitType="conductance" multiplierToSI="1" abbreviation="S"
+    deprecatedInFavorOf="siemens" udunitsSynonym="siemens">
+    <description>siemens</description>
+  </unit>
+
+  <unit id="siemens" name="siemens" unitType="" parentSI="siemens" multiplierToSI="1"
+    abbreviation="S" udunitsSynonym="siemens">
+    <description>SI derived unit of electric conductance, susceptance and admittance 
+      (reciprocals of resistance, reactance, and impedance respectively). One siemens is equal 
+      to the reciprocal of one ohm (and also called "mho")</description>
   </unit>
 
   <!--magneticFlux-->
-  <unit id="weber" name="weber" unitType="magneticFlux" multiplierToSI="1" abbreviation="Wb">
-    <description>weber</description>
+  <unit id="weber" name="weber" unitType="magneticFlux" multiplierToSI="1" abbreviation="Wb"
+    udunitsSynonym="weber">
+    <description>the SI unit of magnetic flux</description>
   </unit>
 
   <!--magneticFluxDensity-->
-  <unit id="tesla" name="tesla" unitType="magneticFluxDensity" multiplierToSI="1" abbreviation="T">
-    <description>tesla</description>
+  <unit id="tesla" name="tesla" unitType="magneticFluxDensity" multiplierToSI="1" abbreviation="T"
+    udunitsSynonym="tesla">
+    <description>unit for flux density. 1 tesla = 1 Wb/m^2 (one weber per square meter).</description>
   </unit>
 
   <!--pressure-->
-  <unit id="pascal" name="pascal" unitType="pressure" multiplierToSI="1" abbreviation="Pa">
-    <description>pascal</description>
+  <unit id="pascal" name="pascal" unitType="pressure" multiplierToSI="1" abbreviation="Pa"
+    udunitsSynonym="pascal">
+    <description>SI derived unit of pressure, 1 pascal = 1 newton/m^2</description>
   </unit>
-  <unit id="megapascal" name="megapascal" unitType="pressure" parentSI="pascal" multiplierToSI="1000000" abbreviation="MPa">
-    <description>megapascal</description>
+  <unit id="megapascal" name="megapascal" unitType="pressure" parentSI="pascal"
+    multiplierToSI="1000000" abbreviation="MPa" udunitsSynonym="megapascal">
+    <description>SI derived unit of pressure, 1 pascal = 1 newton/m^2</description>
   </unit>
-  <unit id="kilopascal" name="kilopascal" unitType="pressure" parentSI="pascal" multiplierToSI="1000" abbreviation="kPa">
-    <description>kilopascal</description>
+  <unit id="kilopascal" name="kilopascal" unitType="pressure" parentSI="pascal"
+    multiplierToSI="1000" abbreviation="kPa" udunitsSynonym="kilopascal">
+    <description>SI derived unit of pressure, 1 pascal = 1 newton/m^2</description>
   </unit>
-
-  <unit id="atmosphere" name="atmosphere" parentSI="pascal" unitType="pressure" multiplierToSI="101325" abbreviation="atm">
-    <description>1 atmosphere = 101325 pascals </description>
+  <unit id="hectopascal" name="hectopascal" parentSI="pascal" unitType="pressure" multiplierToSI="100"
+    abbreviation="hPa" udunitsSynonym="hectopascal">
+    <description>SI derived unit of pressure, 1 pascal = 1 newton/m^2</description>
   </unit>
-  <unit id="bar" name="bar" parentSI="pascal" unitType="pressure" multiplierToSI="100000" abbreviation="bar">
-    <description>1 bar = 100000 pascals</description>
+  
+  <unit id="atmosphere" name="atmosphere" parentSI="pascal" unitType="pressure"
+    multiplierToSI="101325" abbreviation="atm" udunitsSynonym="standard_atmosphere">
+    <description>unit of pressure defined as 101325 Pa (1.01325 bar), sometimes used as a 
+      reference or standard pressure</description>
   </unit>
-  <unit id="millibar" name="millibar" parentSI="pascal" unitType="pressure" multiplierToSI="100" abbreviation="mbar">
-    <description>millibar</description>
+  <unit id="bar" name="bar" parentSI="pascal" unitType="pressure" multiplierToSI="100000"
+    abbreviation="bar" udunitsSynonym="bar">
+    <description>non-SI unit for pressure (deprecated in some fields). 1 bar = 100000 Pa</description>
   </unit>
+  <unit id="millibar" name="millibar" parentSI="pascal" unitType="pressure" multiplierToSI="100"
+    abbreviation="mbar" udunitsSynonym="millibar">
+    <description>non-SI unit for pressure (deprecated in some fields). 1 millibar = 1 hPa (100 Pa)</description>
+  </unit>
+  <unit id="decibar" name="decibar" parentSI="pascal" unitType="pressure" multiplierToSI="10000"
+    abbreviation="dbar" udunitsSynonym="decibar">
+    <description>non-SI unit for pressure. 1 decibar = .1 bar. Decibars are commonly used in aquatic 
+      environments because 1 db is approximately equal to depth in meters.</description>
+  </unit>
+ 
 
   <!--arealMassDensity-->
-  <unit id="kilogramsPerSquareMeter" name="kilogramsPerSquareMeter" unitType="arealMassDensity" multiplierToSI="1" abbreviation="kg/m²">
+  <!--deprecated -->
+  <unit id="kilogramsPerSquareMeter" name="kilogramsPerSquareMeter" unitType="arealMassDensity"
+    multiplierToSI="1" abbreviation="kg/m²" deprecatedInFavorOf="kilogramPerMeterSquared"
+    udunitsSynonym="kilogram/meter^2">
     <description>kilograms per square meter</description>
   </unit>
-  <unit id="gramsPerSquareMeter" name="gramsPerSquareMeter" parentSI="kilogramsPerSquareMeter" unitType="arealMassDensity" multiplierToSI="0.001" abbreviation="g/m²">
+  <unit id="gramsPerSquareMeter" name="gramsPerSquareMeter" parentSI="kilogramPerMeterSquared"
+    unitType="arealMassDensity" multiplierToSI="0.001" abbreviation="g/m²"
+    deprecatedInFavorOf="gramPerMeterSquared" udunitsSynonym="gram/meter^2">
     <description>grams per square meter</description>
   </unit>
-  <unit id="milligramsPerSquareMeter" name="milligramsPerSquareMeter" unitType="arealMassDensity" parentSI="kilogramsPerSquareMeter" multiplierToSI="0.000001" abbreviation="mg/m²">
+  <unit id="milligramsPerSquareMeter" name="milligramsPerSquareMeter" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.000001" abbreviation="mg/m²"
+    deprecatedInFavorOf="milligramPerMeterSquared" udunitsSynonym="milligram/meter^2">
     <description>milligrams Per Square Meter</description>
   </unit>
-  <unit id="kilogramsPerHectare" name="kilogramsPerHectare" unitType="arealMassDensity" parentSI="kilogramsPerSquareMeter" multiplierToSI="0.0001">
+  <unit id="kilogramsPerHectare" name="kilogramsPerHectare" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.0001"
+    deprecatedInFavorOf="kilogramPerHectare" udunitsSynonym="kilogram/hectare">
     <description>kilograms per hectare</description>
   </unit>
-  <unit id="tonnePerHectare" name="tonnePerHectare" unitType="arealMassDensity" parentSI="kilogramsPerSquareMeter" multiplierToSI="0.1">
+  
+  <unit id="tonnePerHectare" name="tonnePerHectare" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.1" udunitsSynonym="metric_ton/hectare">
     <description>metric ton or tonne per hectare</description>
   </unit>
-    <unit id="poundsPerSquareInch" name="poundsPerSquareInch" unitType="arealMassDensity" parentSI="kilogramsPerSquareMeter" multiplierToSI="17.85" abbreviation="lbs/in²">
+  <unit id="poundsPerSquareInch" name="poundsPerSquareInch" unitType="arealMassDensity" 
+    parentSI="kilogramPerMeterSquared" multiplierToSI="703.0696" abbreviation="lbs/in²"
+    deprecatedInFavorOf="poundPerInchSquared"
+    udunitsSynonym="avoirdupois_pound/international_inch^2">
     <description>lbs/square inch</description>
   </unit>
 
+  <unit id="gramPercentimeterSquared" name="gramPercentimeterSquared" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="10" abbreviation="g/cm²"
+    udunitsSynonym="gram/cm^2">
+    <description>grams per square meter</description>
+  </unit>
+  <unit id="gramPerMeterSquared" name="gramPerMeterSquared" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.001" abbreviation="g/m²"
+    udunitsSynonym="gram/meter^2">
+    <description>grams per square meter</description>
+  </unit>
+  <unit id="kilogramPerHectare" name="kilogramPerHectare" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.0001" abbreviation="kg/hectare"
+    udunitsSynonym="kilogram/hectare">
+    <description>kilograms per hectare</description>
+  </unit>
+  <unit id="kilogramPerMeterSquared" name="kilogramPerMeterSquared" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="1" abbreviation="kg/m²"
+    udunitsSynonym="kilogram/meter^2">
+    <description>kilograms per square meter</description>
+  </unit>
+  <unit id="milligramPerMeterSquared" name="milligramPerMeterSquared" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.000001" abbreviation="mg/m²"
+    udunitsSynonym="milligram/meter^2">
+    <description>milligrams Per Square Meter</description>
+  </unit>
+  <unit id="poundPerAcre" name="poundPerAcre" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="0.000112084667279431" abbreviation="lb/acre"
+    udunitsSynonym="avoirdupois_pound/acre">
+    <description>avoirdupois pounds per acre</description>
+  </unit>
+  <unit id="poundPerInchSquared" name="poundPerInchSquared" unitType="arealMassDensity"
+    parentSI="kilogramPerMeterSquared" multiplierToSI="703.0696" abbreviation="lbs/in²"
+    udunitsSynonym="avoirdupois_pound/international_inch^2">
+    <description>avoirdupois pounds per square inch</description>
+  </unit>
+
+
   <!--massDensity-->
-  <unit id="kilogramPerCubicMeter" name="kilogramPerCubicMeter" unitType="massDensity" multiplierToSI="1">
+  <unit id="kilogramPerCubicMeter" name="kilogramPerCubicMeter" unitType="massDensity"
+    multiplierToSI="1" deprecatedInFavorOf="kilogramPerMeterCubed" udunitsSynonym="kilogram/meter^3">
     <description>kilogram per cubic meter</description>
   </unit>
-  <unit id="milliGramsPerMilliLiter" name="milliGramsPerMilliLiter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="1" abbreviation="kg/m³">
+  
+  <unit id="milliGramsPerMilliLiter" name="milliGramsPerMilliLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1" abbreviation="kg/m³"
+    deprecatedInFavorOf="milligramPerMilliliter" udunitsSynonym="milligram/milliliter">
     <description>milligrams per milliliter</description>
   </unit>
-  <unit id="gramsPerLiter" name="gramsPerLiter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="1" abbreviation="g/l">
+  <unit id="gramsPerLiter" name="gramsPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1" abbreviation="g/l"
+    deprecatedInFavorOf="gramPerLiter" udunitsSynonym="gram/liter">
     <description>grams per liter</description>
   </unit>
-  <unit id="milligramsPerCubicMeter" name="milligramsPerCubicMeter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="0.000001" abbreviation="mg/m³">
+  <unit id="milligramsPerCubicMeter" name="milligramsPerCubicMeter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.000001" abbreviation="mg/m³"
+    deprecatedInFavorOf="milligramPerMeterCubed" udunitsSynonym="milligram/meter^3">
     <description>milligrams Per Cubic Meter</description>
   </unit>
-  <unit id="microgramsPerLiter" name="microgramsPerLiter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="0.000001" abbreviation="μg/l">
-    <description>micrograms / liter</description>
+  <unit id="microgramsPerLiter" name="microgramsPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.000001" abbreviation="μg/l"
+    deprecatedInFavorOf="microgramPerLiter" udunitsSynonym="microgram/liter">
+    <description>micrograms/liter</description>
   </unit>
-  <unit id="milligramsPerLiter" name="milligramsPerLiter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="0.001" abbreviation="mg/l">
-    <description>milligrams / liter</description>
+  <unit id="milligramsPerLiter" name="milligramsPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.001" abbreviation="mg/l"
+    deprecatedInFavorOf="milligramPerLiter" udunitsSynonym="milligram/liter">
+    <description>milligrams/liter</description>
   </unit>
-  <unit id="gramsPerCubicCentimeter" name="gramsPerCubicCentimeter" unitType="massDensity" parentSI="kilogramsPerCubicMeter" multiplierToSI="1000" abbreviation="g/cm³">
+  <unit id="gramsPerCubicCentimeter" name="gramsPerCubicCentimeter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1000" abbreviation="g/cm³"
+    deprecatedInFavorOf="gramPerCentimeterCubed" udunitsSynonym="gram/centimeter^3">
     <description>grams per cubic centimeter</description>
   </unit>
-  <unit id="gramsPerMilliliter" name="gramsPerMilliliter" unitType="massDensity"  parentSI="kilogramsPerCubicMeter" multiplierToSI="1000" abbreviation="g/ml">
+  <unit id="gramsPerMilliliter" name="gramsPerMilliliter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1000" abbreviation="g/ml"
+    deprecatedInFavorOf="gramPerMilliliter" udunitsSynonym="gram/milliliter">
     <description>grams per milliliter</description>
   </unit>
 
+  <unit id="gramPerCentimeterCubed" name="gramPerCentimeterCubed" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1000" abbreviation="g/cm³"
+    udunitsSynonym="gram/centimeter^3">
+    <description>grams per cubic centimeter</description>
+  </unit>
+  <unit id="gramPerLiter" name="gramPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1" abbreviation="g/l"
+    udunitsSynonym="gram/liter">
+    <description>grams per liter</description>
+  </unit>
+  <unit id="gramPerMilliliter" name="gramPerMilliliter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1000" abbreviation="g/ml"
+    udunitsSynonym="gram/milliliter">
+    <description>grams per milliliter</description>
+  </unit>
+  <unit id="microgramPerLiter" name="microgramPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.000001" abbreviation="μg/l"
+    udunitsSynonym="microgram/liter">
+    <description>micrograms/liter</description>
+  </unit>
+  <unit id="milligramPerLiter" name="milligramPerLiter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.001" abbreviation="mg/l"
+    udunitsSynonym="milligram/liter">
+    <description>milligrams/liter</description>
+  </unit>
+  <unit id="milligramPerMeterCubed" name="milligramPerMeterCubed" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="0.000001" abbreviation="mg/m³"
+    udunitsSynonym="milligram/meter^3">
+    <description>milligrams Per Cubic Meter</description>
+  </unit>
+  <unit id="kilogramPerMeterCubed" name="kilogramPerMeterCubed" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1" abbreviation="kg/m³"
+    udunitsSynonym="kilogram/meter^3">
+    <description>kilograms per cubic meter</description>
+  </unit>
+  <unit id="megagramPerMeterCubed" name="megagramPerMeterCubed" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1000" abbreviation="Mg/m³"
+    udunitsSynonym="megagram/meter^3">
+    <description>megagrams per cubic meter</description>
+  </unit>
+  <unit id="milligramPerMilliliter" name="milligramPerMilliliter" unitType="massDensity"
+    parentSI="kilogramPerMeterCubed" multiplierToSI="1" abbreviation="mg/ml"
+    udunitsSynonym="milligram/milliliter">
+    <description>micromoles per square meter per second</description>
+  </unit>
+
+
   <!--volumetricMassDensityRate-->
-  <unit id="gramsPerLiterPerDay" name="gramsPerLiterPerDay" unitType="volumetricMassDensityRate" multiplierToSI="1">
+  <unit id="gramsPerLiterPerDay" name="gramsPerLiterPerDay" unitType="volumetricMassDensityRate"
+    multiplierToSI="1" deprecatedInFavorOf="gramPerDayPerLiter" udunitsSynonym="gram/liter/day">
+    <description>grams Per (Liter Per Day)</description>
+  </unit>
+  <unit id="milligramPerMeterCubedPerDay" name="milligramPerMeterCubedPerDay"
+    unitType="volumetricMassDensityRate" parentSI="kilogramPerMeterCubedPerSecond" multiplierToSI="0.0000015741"
+    abbreviation="mg/m3/d" udunitsSynonym="milligram/meter^3/day">
+    <description>milligram per cubic meter per day</description>
+  </unit>
+
+
+
+
+  <unit id="gramPerDayPerLiter" name="gramPerDayPerLiter" unitType="volumetricMassDensityRate"
+    parentSI="gramPerDayPerLiter" multiplierToSI="1" abbreviation="g/d/l"
+    udunitsSynonym="gram/day/liter">
     <description>grams Per (Liter Per Day)</description>
   </unit>
 
   <!--volumetricRate-->
-  <unit id="litersPerSecond" name="litersPerSecond" unitType="volumetricRate" multiplierToSI="1" abbreviation="l/s">
+  <unit id="litersPerSecond" name="litersPerSecond" unitType="volumetricRate" multiplierToSI="1"
+    abbreviation="l/s" deprecatedInFavorOf="literPerSecond" udunitsSynonym="liter/second">
     <description>liters per second</description>
   </unit>
-  <unit id="cubicMetersPerSecond" name="cubicMetersPerSecond" unitType="volumetricRate" parentSI="litersPerSecond" multiplierToSI="1" abbreviation="m³/s">
+  <unit id="cubicMetersPerSecond" name="cubicMetersPerSecond" unitType="volumetricRate"
+    parentSI="literPerSecond" multiplierToSI="1000" abbreviation="m³/s"
+    deprecatedInFavorOf="meterCubedPerSecond" udunitsSynonym="meter^3/second">
     <description>cubic meters per second</description>
   </unit>
-  <unit id="cubicFeetPerSecond" name="cubicFeetPerSecond" unitType="volumetricRate" parentSI="litersPerSecond" multiplierToSI="28.316874" abbreviation="ft³/sec">
+  <unit id="cubicFeetPerSecond" name="cubicFeetPerSecond" unitType="volumetricRate"
+    parentSI="literPerSecond" multiplierToSI="28.316874" abbreviation="ft³/s"
+    deprecatedInFavorOf="footCubedPerSecond" udunitsSynonym="international_foot^3/second">
     <description>cubic feet per second</description>
   </unit>
 
+  <unit id="footCubedPerSecond" name="footCubedPerSecond" unitType="volumetricRate"
+    parentSI="literPerSecond" multiplierToSI="28.316874" abbreviation="ft³/s"
+    udunitsSynonym="international_foot^3/second">
+    <description>cubic feet per second</description>
+  </unit>
+  <unit id="literPerSecond" name="literPerSecond" unitType="volumetricRate"
+    parentSI="literPerSecond" multiplierToSI="1" abbreviation="l/s" udunitsSynonym="liter/second">
+    <description>liters per second</description>
+  </unit>
+  <unit id="meterCubedPerSecond" name="meterCubedPerSecond" unitType="volumetricRate"
+    parentSI="literPerSecond" multiplierToSI="1000" abbreviation="m³/s"
+    udunitsSynonym="meter^3/second">
+    <description>cubic meters per second</description>
+  </unit>
+
+
   <!--area-->
-  <unit id="squareMeter" name="squareMeter" unitType="area" multiplierToSI="1" abbreviation="m²">
+  <unit id="squareMeter" name="squareMeter" unitType="area" multiplierToSI="1" abbreviation="m²"
+    deprecatedInFavorOf="meterSquared" udunitsSynonym="meter^2">
     <description>square meters</description>
   </unit>
-  <unit id="are" name="are" unitType="area" parentSI="squareMeter" multiplierToSI="100" abbreviation="a">
+  <unit id="are" name="are" unitType="area" parentSI="squareMeter" multiplierToSI="100"
+    abbreviation="a" udunitsSynonym="are">
     <description>100 square meters</description>
   </unit>
-  <unit id="hectare" name="hectare" unitType="area" parentSI="squareMeter" multiplierToSI="10000" abbreviation="ha">
+  <unit id="hectare" name="hectare" unitType="area" parentSI="squareMeter" multiplierToSI="10000"
+    abbreviation="ha" udunitsSynonym="hectare">
     <description>1 hectare is 10^4 square meters</description>
   </unit>
-  <unit id="squareKilometers" name="squareKilometers" unitType="area" parentSI="squareMeter" multiplierToSI="1000000">
+  <unit id="squareKilometers" name="squareKilometers" unitType="area" parentSI="squareMeter"
+    multiplierToSI="1000000" deprecatedInFavorOf="kilometerSquared" udunitsSynonym="kilometer^2">
     <description>square kilometers</description>
   </unit>
-  <unit id="squareMillimeters" name="squareMillimeters" unitType="area" parentSI="squareMeter" multiplierToSI="0.000001">
+  <unit id="squareMillimeters" name="squareMillimeters" unitType="area" parentSI="squareMeter"
+    multiplierToSI="0.000001" deprecatedInFavorOf="millimeterSquared" udunitsSynonym="millimeter^2">
     <description>square millmeters</description>
   </unit>
-  <unit id="squareCentimeters" name="squareCentimeters" unitType="area" parentSI="squareMeter" multiplierToSI="0.0001">
+  <unit id="squareCentimeters" name="squareCentimeters" unitType="area" parentSI="squareMeter"
+    multiplierToSI="0.0001" deprecatedInFavorOf="centimeterSquared" udunitsSynonym="centimeter^2">
     <description>square centimeters</description>
   </unit>
 
-  <unit id="acre" name="acre" unitType="area" parentSI="squareMeter" multiplierToSI="4046.8564" abbreviation="a">
+  <unit id="acre" name="acre" unitType="area" parentSI="squareMeter" multiplierToSI="4046.8564"
+    abbreviation="a" udunitsSynonym="acre">
     <description>1 acre = 4046.8564 square meters or 1 hectare = 2.4710 acres</description>
   </unit>
 
-  <unit id="squareFoot" name="squareFoot" unitType="area" parentSI="squareMeter" multiplierToSI="0.092903" abbreviation="ft²">
+  <unit id="squareFoot" name="squareFoot" unitType="area" parentSI="squareMeter"
+    multiplierToSI="0.092903" abbreviation="ft²" deprecatedInFavorOf="footSquared"
+    udunitsSynonym="international_foot^2">
     <description>12 inches squared</description>
   </unit>
-  <unit id="squareYard" name="squareYard" unitType="area" parentSI="squareMeter" multiplierToSI="0.836131" abbreviation="yd²">
+  <unit id="squareYard" name="squareYard" unitType="area" parentSI="squareMeter"
+    multiplierToSI="0.836131" abbreviation="yd²" deprecatedInFavorOf="yardSquared"
+    udunitsSynonym="international_yard^2">
     <description>36 inches squared</description>
   </unit>
-  <unit id="squareMile" name="squareMile" unitType="area" parentSI="squareMeter" multiplierToSI="2589998.49806" abbreviation="mile²">
+  <unit id="squareMile" name="squareMile" unitType="area" parentSI="squareMeter"
+    multiplierToSI="2589998.49806" abbreviation="mile²" deprecatedInFavorOf="mileSquared"
+    udunitsSynonym="international_mile^2">
     <description>1 mile squared</description>
   </unit>
 
+  <unit id="centimeterSquared" name="centimeterSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="0.0001" abbreviation="cm²" udunitsSynonym="centimeter^2">
+    <description>square centimeter</description>
+  </unit>
+  <unit id="footSquared" name="footSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="0.092903" abbreviation="ft²" udunitsSynonym="international_foot^2">
+    <description>12 inches squared</description>
+  </unit>
+  <unit id="kilometerSquared" name="kilometerSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="1000000" abbreviation="km²" udunitsSynonym="kilometer^2">
+    <description>square kilometer</description>
+  </unit>
+  <unit id="meterSquared" name="meterSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="1" abbreviation="m²" udunitsSynonym="meter^2">
+    <description>square meters</description>
+  </unit>
+  <unit id="mileSquared" name="mileSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="2589998.49806" abbreviation="mile²" udunitsSynonym="international_mile^2">
+    <description>1 mile squared</description>
+  </unit>
+  <unit id="millimeterSquared" name="millimeterSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="0.000001" abbreviation="mm²" udunitsSynonym="millimeter^2">
+    <description>square millimeter</description>
+  </unit>
+  <unit id="yardSquared" name="yardSquared" unitType="area" parentSI="meterSquared"
+    multiplierToSI="0.836131" abbreviation="yd²" udunitsSynonym="international_yard^2">
+    <description>36 inches squared</description>
+  </unit>
+
   <!--volumetricArea-->
-  <unit id="litersPerSquareMeter" name="litersPerSquareMeter" unitType="volumetricArea" multiplierToSI="1" abbreviation="l/m²">
+  <unit id="litersPerSquareMeter" name="litersPerSquareMeter" unitType="volumetricArea"
+    multiplierToSI="1" abbreviation="l/m²" deprecatedInFavorOf="literPerMeterSquared"
+    udunitsSynonym="liter/meter^2">
     <description>liters per square meter</description>
   </unit>
-  <unit id="bushelsPerAcre" name="bushelsPerAcre" unitType="volumetricArea" parentSI="litersPerSquareMeter" multiplierToSI="0.00870">
-    <description>bushels per acre -- 1 bushel = 35.23907 liters/1 acre = 4046.8564 squareMeters</description>
+  <unit id="bushelsPerAcre" name="bushelsPerAcre" unitType="volumetricArea"
+    parentSI="literPerMeterSquared" multiplierToSI="0.00870" deprecatedInFavorOf="bushelPerAcre"
+    udunitsSynonym="bushel/acre">
+    <description>bushels per acre, 1 bushel = 35.23907 liters/1 acre = 4046.8564
+      squareMeters</description>
   </unit>
-  <unit id="litersPerHectare" name="litersPerHectare" unitType="volumetricArea" parentSI="litersPerSquareMeter" multiplierToSI="0.0001">
+  <unit id="litersPerHectare" name="litersPerHectare" unitType="volumetricArea"
+    parentSI="literPerMeterSquared" multiplierToSI="0.0001" deprecatedInFavorOf="literPerHectare"
+    udunitsSynonym="liter/hectare">
     <description>liters per hectare</description>
   </unit>
 
+  <unit id="bushelPerAcre" name="bushelPerAcre" unitType="volumetricArea"
+    parentSI="literPerMeterSquared" multiplierToSI="0.00870" abbreviation="bu/acre"
+    udunitsSynonym="bushel/acre">
+    <description>bushels per acre, 1 bushel = 35.23907 liters/1 acre = 4046.8564
+      squareMeters</description>
+  </unit>
+  <unit id="literPerHectare" name="literPerHectare" unitType="volumetricArea"
+    parentSI="literPerMeterSquared" multiplierToSI="0.0001" abbreviation="l/hectare"
+    udunitsSynonym="liter/hectare">
+    <description>liters per hectare</description>
+  </unit>
+  <unit id="literPerMeterSquared" name="literPerMeterSquared" unitType="volumetricArea"
+    parentSI="literPerMeterSquared" multiplierToSI="1" abbreviation="l/m²"
+    udunitsSynonym="liter/meter^2">
+    <description>liters per square meter</description>
+  </unit>
+  <unit id="meterCubedPerHectare" name="meterCubedPerHectare" unitType="volumetricArea"
+    parentSI="meterCubedPerMeterSquared" multiplierToSI="0.0001" abbreviation="m3/ha"
+    udunitsSynonym="m^3/hectare">
+    <description>meter cubed per hectare</description>
+  </unit>
+  <unit id="meterCubedPerMeterSquared" name="meterCubedPerMeterSquared" unitType="volumetricArea"
+    parentSI="meterCubedPerMeterSquared" multiplierToSI="1" abbreviation="m^3/m^2"
+    udunitsSynonym="m^3/m^2">
+    <description>meter cubed per meter squared</description>
+  </unit>
+  
+  <!-- area ratio -->
+  <unit id="meterSquaredPerHectare" name="meterSquaredPerHectare" unitType="volumetricArea"
+    parentSI="meterSquaredPerMeterSquared" multiplierToSI="0.0001" abbreviation="m^2/ha"
+    udunitsSynonym="m^2/hectare">
+    <description>meter squared per hectare</description>
+  </unit>
+
   <!--specificArea-->
-  <unit id="squareMeterPerKilogram" name="squareMeterPerKilogram" unitType="specificArea" multiplierToSI="1" abbreviation="m²/kg">
+  <unit id="squareMeterPerKilogram" name="squareMeterPerKilogram" unitType="specificArea"
+    multiplierToSI="1" abbreviation="m²/kg" deprecatedInFavorOf="meterSquaredPerKilogram"
+    udunitsSynonym="meter^2/kilogram">
     <description>square meters per kilogram</description>
   </unit>
 
-  <!--speed-->
-  <unit id="metersPerSecond" name="metersPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="1" abbreviation="m/s">
+  <unit id="meterSquaredPerKilogram" name="meterSquaredPerKilogram" unitType="specificArea"
+    parentSI="meterSquaredPerKilogram" multiplierToSI="1" abbreviation="m²/kg"
+    udunitsSynonym="meter^2/kilogram">
+    <description>square meters per kilogram</description>
+  </unit>
+
+  <!--speed (length per time) -->
+  <unit id="metersPerSecond" name="metersPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="1" abbreviation="m/s" deprecatedInFavorOf="meterPerSecond"
+    udunitsSynonym="meter/second">
     <description>meters per second</description>
   </unit>
-  <unit id="metersPerDay" name="metersPerDay" unitType="speed" multiplierToSI=".0000115741" abbreviation="m/day">
+  <unit id="metersPerDay" name="metersPerDay" unitType="speed" multiplierToSI=".0000115741"
+    abbreviation="m/day" deprecatedInFavorOf="meterPerDay" udunitsSynonym="meter/day">
     <description>meters per day</description>
   </unit>
-  <unit id="feetPerDay" name="feetPerDay" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.00000352778"  abbreviation="ft/day">
+  <unit id="feetPerDay" name="feetPerDay" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.00000352778" abbreviation="ft/day" deprecatedInFavorOf="footPerDay"
+    udunitsSynonym="international_foot/day">
     <description>feet per day</description>
   </unit>
-  <unit id="feetPerSecond" name="feetPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.3048"  abbreviation="ft/s">
+  <unit id="feetPerSecond" name="feetPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.3048" abbreviation="ft/s" deprecatedInFavorOf="footPerSecond"
+    udunitsSynonym="international_foot/second">
     <description>feet per second</description>
   </unit>
-  <unit id="feetPerHour" name="feetPerHour" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.000084667" abbreviation="ft/hr">
+  <unit id="feetPerHour" name="feetPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.000084667" abbreviation="ft/hr" deprecatedInFavorOf="footPerHour"
+    udunitsSynonym="international_foot/hour">
     <description>feet per hour</description>
   </unit>
-  <unit id="yardsPerSecond" name="yardsPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.9144"  abbreviation="yd/s">
+  <unit id="yardsPerSecond" name="yardsPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.9144" abbreviation="yd/s" deprecatedInFavorOf="yardPerSecond"
+    udunitsSynonym="international_yard/second">
     <description>yards per second</description>
   </unit>
-  <unit id="milesPerHour" name="milesPerHour" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.44704"  abbreviation="mph">
+  <unit id="milesPerHour" name="milesPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.44704" abbreviation="mph" deprecatedInFavorOf="milePerHour"
+    udunitsSynonym="international_mile/hour">
     <description>miles per hour</description>
   </unit>
-  <unit id="milesPerSecond" name="milesPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="1609.344" abbreviation="mps">
+  <unit id="milesPerSecond" name="milesPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="1609.344" abbreviation="mps" deprecatedInFavorOf="milePerSecond"
+    udunitsSynonym="international_mile/second">
     <description>miles per second</description>
   </unit>
-  <unit id="milesPerMinute" name="milesPerMinute" unitType="speed" parentSI="metersPerSecond" multiplierToSI="26.8224" abbreviation="mpm">
+  <unit id="milesPerMinute" name="milesPerMinute" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="26.8224" abbreviation="mpm" deprecatedInFavorOf="milePerMinute"
+    udunitsSynonym="international_mile/minute">
     <description>miles per minute</description>
   </unit>
-  <unit id="centimetersPerSecond" name="centimetersPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.01" abbreviation="cm/s">
+  <unit id="centimetersPerSecond" name="centimetersPerSecond" unitType="speed"
+    parentSI="meterPerSecond" multiplierToSI="0.01" abbreviation="cm/s"
+    deprecatedInFavorOf="centimeterPerSecond" udunitsSynonym="centimeter/second">
     <description>centimeters per second</description>
   </unit>
-  <unit id="millimetersPerSecond" name="millimetersPerSecond" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.001" abbreviation="mm/s">
+  <unit id="millimetersPerSecond" name="millimetersPerSecond" unitType="speed"
+    parentSI="meterPerSecond" multiplierToSI="0.001" abbreviation="mm/s"
+    deprecatedInFavorOf="millimeterPerSecond" udunitsSynonym="millimeter/second">
     <description>millimeters per second</description>
   </unit>
-  <unit id="centimeterPerYear" name="centimeterPerYear" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.000000000317098" abbreviation="cm/year">
+  <unit id="centimeterPerYear" name="centimeterPerYear" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.000000000317098" abbreviation="cm/year"
+    deprecatedInFavorOf="centimeterPerYear" udunitsSynonym="centimeter/common_year">
     <description>centimeter Per Year</description>
   </unit>
-  <unit id="knots" name="knots" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.514444">
+  <unit id="knots" name="knots" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.514444" deprecatedInFavorOf="knot" udunitsSynonym="international_knot">
     <description>knots</description>
   </unit>
-  <unit id="kilometersPerHour" name="kilometersPerHour" unitType="speed" parentSI="metersPerSecond" multiplierToSI="0.2778" abbreviation="km/hr">
+  <unit id="kilometersPerHour" name="kilometersPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.2778" abbreviation="km/hr" deprecatedInFavorOf="kilometerPerHour"
+    udunitsSynonym="kilometer/hour">
     <description>km/hr</description>
   </unit>
 
+  <unit id="centimeterPerSecond" name="centimeterPerSecond" unitType="speed"
+    parentSI="meterPerSecond" multiplierToSI="0.01" abbreviation="cm/s"
+    udunitsSynonym="centimeter/second">
+    <description>centimeters per second</description>
+  </unit>
+  <unit id="footPerDay" name="footPerDay" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.00000352778" abbreviation="ft/day" udunitsSynonym="international_foot/day">
+    <description>feet per day</description>
+  </unit>
+  <unit id="footPerHour" name="footPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.000084667" abbreviation="ft/hr" udunitsSynonym="international_foot/hour">
+    <description>feet per hour</description>
+  </unit>
+  <unit id="footPerSecond" name="footPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.3048" abbreviation="ft/s" udunitsSynonym="international_foot/second">
+    <description>feet per second</description>
+  </unit>
+  <unit id="inchPerHour" name="inchPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.00000705556" abbreviation="in/hr" 
+    udunitsSynonym="international_inch/hour">
+    <description>inches per hour</description>
+  </unit>
+  <unit id="kilometerPerHour" name="kilometerPerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.2778" abbreviation="km/hr" udunitsSynonym="kilometer/hour">
+    <description>km/hr</description>
+  </unit>
+  <unit id="knot" name="knot" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.514444444444444" abbreviation="knot" udunitsSynonym="international_knot">
+    <description>unit of speed equal to one nautical mile per hour, exactly 1.852 km/hour</description>
+  </unit>
+  <unit id="meterPerDay" name="meterPerDay" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI=".0000115741" abbreviation="m/day" udunitsSynonym="meter/day">
+    <description>meters per day</description>
+  </unit>
+  <unit id="meterPerSecond" name="meterPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="1" abbreviation="m/s" udunitsSynonym="meter/second">
+    <description>meters per second</description>
+  </unit>
+  <unit id="milePerHour" name="milePerHour" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.44704" abbreviation="mph" udunitsSynonym="international_mile/hour">
+    <description>miles per hour</description>
+  </unit>
+  <unit id="milePerMinute" name="milePerMinute" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="26.8224" abbreviation="mpm" udunitsSynonym="international_mile/minute">
+    <description>miles per minute</description>
+  </unit>
+  <unit id="milePerSecond" name="milePerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="1609.344" abbreviation="mps" udunitsSynonym="international_mile/second">
+    <description>miles per second</description>
+  </unit>
+  <unit id="millimeterPerDay" name="millimeterPerDay" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.00000001157407" abbreviation="mm/d" udunitsSynonym="millimeter/day">
+    <description>millimeters per day</description>
+  </unit>
+  <unit id="millimeterPerSecond" name="millimeterPerSecond" unitType="speed"
+    parentSI="meterPerSecond" multiplierToSI="0.001" abbreviation="mm/s"
+    udunitsSynonym="millimeter/second">
+    <description>millimeters per second</description>
+  </unit>
+  <unit id="yardPerSecond" name="yardPerSecond" unitType="speed" parentSI="meterPerSecond"
+    multiplierToSI="0.9144" abbreviation="yd/s" udunitsSynonym="international_yard/second">
+    <description>yards per second</description>
+  </unit>
+
   <!--acceleration-->
-  <unit id="metersPerSecondSquared" name="metersPerSecondSquared" unitType="acceleration" multiplierToSI="1" abbreviation="m/s²">
+  <unit id="metersPerSecondSquared" name="metersPerSecondSquared" unitType="acceleration"
+    multiplierToSI="1" abbreviation="m/s²" deprecatedInFavorOf="meterPerSecondSquared"
+    udunitsSynonym="meter/second^2">
     <description>meters per second squared</description>
   </unit>
 
-  <!--waveNumber-->
-  <unit id="waveNumber" name="waveNumber" unitType="lengthReciprocal" multiplierToSI="1">
+  <unit id="meterPerSecondSquared" name="meterPerSecondSquared" unitType="acceleration"
+    parentSI="meterPerSecondSquared" multiplierToSI="1" abbreviation="m/s²"
+    udunitsSynonym="meter/second^2">
+    <description>micromoles per square meter per second</description>
+  </unit>
+
+  <!--reciprocal lengths-->
+  <unit id="waveNumber" name="waveNumber" unitType="lengthReciprocal" multiplierToSI="1"
+    deprecatedInFavorOf="inverseMeter" udunitsSynonym="meter^-1">
     <description>1/meters</description>
+  </unit>
+  <unit id="inverseMeter" name="inverseMeter" unitType="lengthReciprocal" multiplierToSI="1"
+    udunitsSynonym="meter^-1">
+    <description>reciprocal of meter, or 1/meters</description>
+  </unit>
+  <unit id="inverseCentimeter" name="inverseCentimeter" unitType="lengthReciprocal"
+    multiplierToSI=".01" udunitsSynonym="meter^-1">
+    <description>also called reciprocal centimeter</description>
   </unit>
 
   <!--specificVolume-->
-  <unit id="cubicMeterPerKilogram" name="cubicMeterPerKilogram" unitType="specificVolume" multiplierToSI="1" abbreviation="m³/kg">
+  <unit id="cubicMeterPerKilogram" name="cubicMeterPerKilogram" unitType="specificVolume"
+    multiplierToSI="1" abbreviation="m³/kg" deprecatedInFavorOf="meterCubedPerKilogram"
+    udunitsSynonym="meter^3/kilogram">
     <description>cubic meters per kilogram</description>
   </unit>
 
-  <unit id="cubicMicrometersPerGram" name="cubicMicrometersPerGram" unitType="specificVolume" parentSI="cubicMeterPerKilogram" multiplierToSI="0.000000000000001" abbreviation="μm³/kg">
+  <unit id="cubicMicrometersPerGram" name="cubicMicrometersPerGram" unitType="specificVolume"
+    parentSI="cubicMeterPerKilogram" multiplierToSI="0.000000000000001" abbreviation="μm³/kg"
+    deprecatedInFavorOf="micrometerCubedPerGram" udunitsSynonym="micrometer^3/gram">
+    <description>cubic micrometers per gram</description>
+  </unit>
+
+  <unit id="meterCubedPerKilogram" name="meterCubedPerKilogram" unitType="specificVolume"
+    parentSI="meterCubedPerKilogram" multiplierToSI="1" abbreviation="m³/kg"
+    udunitsSynonym="meter^3/kilogram">
+    <description>cubic meters per kilogram</description>
+  </unit>
+  <unit id="micrometerCubedPerGram" name="micrometerCubedPerGram" unitType="specificVolume"
+    parentSI="meterCubedPerKilogram" multiplierToSI="0.000000000000001" abbreviation="μm³/kg"
+    udunitsSynonym="micrometer^3/gram">
     <description>cubic micrometers per gram</description>
   </unit>
 
   <!--currentDensity-->
-  <unit id="amperePerSquareMeter" name="amperePerSquareMeter" unitType="currentDensity" multiplierToSI="1" abbreviation="A/m²">
-    <description>ampere per meter squared</description>
+  <unit id="amperePerSquareMeter" name="amperePerSquareMeter" unitType="currentDensity"
+    multiplierToSI="1" abbreviation="A/m²" deprecatedInFavorOf="amperePerMeterSquared"
+    udunitsSynonym="ampere/meter^2">
+    <description>ampere per meter squared, unit of current density</description>
+  </unit>
+
+  <unit id="amperePerMeterSquared" name="amperePerMeterSquared" unitType="currentDensity"
+    parentSI="amperePerMeterSquared" multiplierToSI="1" abbreviation="A/m²"
+    udunitsSynonym="ampere/meter^2">
+    <description>amperes per square meter, unit of current density</description>
   </unit>
 
   <!--magneticFieldStrength-->
-  <unit id="amperePerMeter" name="amperePerMeter" unitType="magneticFieldStrength" multiplierToSI="1" abbreviation="A/m">
+  <unit id="amperePerMeter" name="amperePerMeter" unitType="magneticFieldStrength"
+    multiplierToSI="1" abbreviation="A/m" udunitsSynonym="ampere/meter">
     <description>ampere per meter</description>
   </unit>
 
   <!--amountOfSubstanceConcentration-->
-  <unit id="molePerCubicMeter" name="molePerCubicMeter" unitType="amountOfSubstanceConcentration" multiplierToSI="1">
+  <unit id="molePerCubicMeter" name="molePerCubicMeter" unitType="amountOfSubstanceConcentration"
+    multiplierToSI="1" deprecatedInFavorOf="molePerMeterCubed" udunitsSynonym="mole/meter^3">
     <description>mole per cubic meter</description>
   </unit>
-  <unit id="molarity" name="molarity" unitType="amountOfSubstanceConcentration" parentSI="molesPerCubicMeter" multiplierToSI="1000" abbreviation="M">
+  <unit id="molarity" name="molarity" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="1000" abbreviation="M"
+    deprecatedInFavorOf="molePerLiter" udunitsSynonym="mole/liter">
     <description>molarity = moles/liter</description>
   </unit>
 
+  <unit id="molePerMeterCubed" name="molePerMeterCubed" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="1" abbreviation="mol/m³"
+    udunitsSynonym="mole/meter^3">
+    <description>moles per cubic meter</description>
+  </unit>
+  <unit id="molePerLiter" name="molePerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="1000" abbreviation="mol/l"
+    udunitsSynonym="mole/liter">
+    <description>moles per liter (perferred over molarity, as molarity refers only to dissolved substances)</description>
+  </unit>
+  <unit id="millimolePerLiter" name="millimolePerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="1" abbreviation="mmol/l"
+    udunitsSynonym="millimole/liter">
+    <description>millimoles per liter </description>
+  </unit>
+  <unit id="micromolePerLiter" name="micromolePerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="0.001" abbreviation="µmol/l"
+    udunitsSynonym="micromole/liter">
+    <description>micromoles per liter</description>
+  </unit>
+  <unit id="nanomolePerLiter" name="nanomolePerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI="0.000001" abbreviation="nmol/l"
+    udunitsSynonym="nanomole/liter">
+    <description>nanomoles per liter</description>
+  </unit>
+  <unit id="millimolePerMeterCubed" name="millimolePerMeterCubed" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" multiplierToSI=".001" abbreviation="mol/m³"
+    udunitsSynonym="millimole/meter^3">
+    <description>millimoles per cubic meter</description>
+  </unit>
+  <!-- concentration of charge -->
+  <unit id="microequivalentPerLiter" name="microequivalentPerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" abbreviation="E/l">
+    <description>concentration of charge (on dissolved ions). conversions must know the name of the ion; 
+      a single multiplier to SI is not possible</description>
+  </unit>
+  <unit id="milliequivalentPerLiter" name="milliequivalentPerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" abbreviation="mE/l">
+    <description>concentration of charge (on dissolved ions). conversions must know the name of the ion; 
+      a single multiplier to SI is not possible</description>
+  </unit>
+  <unit id="equivalentPerLiter" name="equivalentPerLiter" unitType="amountOfSubstanceConcentration"
+    parentSI="molePerMeterCubed" abbreviation="µE/l">
+    <description>concentration of charge (on dissolved ions). conversions must know the name of the ion; 
+      a single multiplier to SI is not possible</description>
+  </unit>
+  
+  
   <!--amountOfSubstanceWeight-->
-  <unit id="molality" name="molality" unitType="amountOfSubstanceWeight" multiplierToSI="1" abbreviation="m">
+  <unit id="molality" name="molality" unitType="amountOfSubstanceWeight" multiplierToSI="1"
+    abbreviation="m" deprecatedInFavorOf="molePerKilogram" udunitsSynonym="mole/kilogram">
     <description>molality = moles/kg</description>
   </unit>
 
-  <!--luminance-->
-  <unit id="candelaPerSquareMeter" name="candelaPerSquareMeter" unitType="luminance" multiplierToSI="1" abbreviation="cd/m²">
-    <description>candela Per Square Meter</description>
+  <unit id="millimolePerGram" name="millimolePerGram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="1" abbreviation="mmol/g"
+    udunitsSynonym="millimole/gram">
+    <description>millimoles per gram</description>
   </unit>
-
-  <!--transmissivity-->
-  <unit id="metersSquaredPerSecond" name="metersSquaredPerSecond" unitType="transmissivity" multiplierToSI="1" abbreviation="m²/s">
-    <description>meters squared per second</description>
-  </unit>
-  <unit id="metersSquaredPerDay" name="metersSquaredPerDay" unitType="transmissivity" parentSI="metersSquaredPerSecond" multiplierToSI="86400" abbreviation="m²/day">
-    <description>meters squared per day</description>
-  </unit>
-  <unit id="feetSquaredPerDay" name="feetSquaredPerDay" unitType="transmissivity" parentSI="metersSquaredPerSecond" multiplierToSI="0.000124586" abbreviation="ft²/day">
-    <description>feet squared per day</description>
-  </unit>
-
-  <!--arealMassDensityRate-->
-  <unit id="kilogramsPerMeterSquaredPerSecond" name="kilogramsPerMeterSquaredPerSecond" unitType="arealMassDensityRate" multiplierToSI="1">
-    <description>kilograms per meter sqared per second</description>
-  </unit>
-  <unit id="gramsPerCentimeterSquaredPerSecond" name="gramsPerCentimeterSquaredPerSecond" unitType="arealMassDensityRate" parentSI="kilogramsPerMeterSquaredPerSecond" multiplierToSI="0.1">
-    <description>grams Per Centimeter Squared Per Second</description>
-  </unit>
-  <unit id="gramsPerMeterSquaredPerYear" name="gramsPerMeterSquaredPerYear" unitType="arealMassDensityRate" parentSI="kilogramsPerMeterSquaredPerSecond" multiplierToSI="0.0000000000317098">
-    <description>grams Per Meter Squared Per Year</description>
-  </unit>
-  <unit id="gramsPerHectarePerDay" name="gramsPerHectarePerDay" unitType="arealMassDensityRate" parentSI="kilogramsPerMeterSquaredPerSecond" multiplierToSI="0.0000000000011574">
-    <description>grams Per Hectare Squared Per Day</description>
-  </unit>
-  <unit id="kilogramsPerHectarePerYear" name="kilogramsPerHectarePerYear" unitType="arealMassDensityRate" parentSI="kilogramsPerMeterSquaredPerSecond" multiplierToSI="0.000317">
-    <description>kilograms Per Hectare Per Year</description>
-  </unit>
-  <unit id="kilogramsPerMeterSquaredPerYear" name="kilogramsPerMeterSquaredPerYear" unitType="arealMassDensityRate" parentSI="kilogramsPerMeterSquaredPerSecond" multiplierToSI="0000000317">
-    <description>kilograms Per Meter Squared Per Year</description>
-  </unit>
-
-  <!--amountOfSubstanceWeight-->
-  <unit id="molesPerKilogram" name="molesPerKilogram" unitType="amountOfSubstanceWeight" multiplierToSI="1">
-    <description>moles per kilogram</description>
-  </unit>
-  <unit id="molesPerGram" name="molesPerGram" unitType="amountOfSubstanceWeight" parentSI="molesPerKilogram" multiplierToSI="1000">
+  <unit id="molePerGram" name="molePerGram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="1000" abbreviation="mol/g" udunitsSynonym="mole/gram">
     <description>moles per gram</description>
   </unit>
-  <unit id="millimolesPerGram" name="millimolesPerGram" unitType="amountOfSubstanceWeight" parentSI="molesPerKilogram" multiplierToSI="1">
+  <unit id="molePerKilogram" name="molePerKilogram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="1" abbreviation="mol/kg"
+    udunitsSynonym="mole/kilogram">
+    <description>moles per kilogram</description>
+  </unit>
+  <unit id="micromolePerGram" name="micromolePerGram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="0.001" abbreviation="umol/g"
+    udunitsSynonym="micromole/gram">
     <description>millimoles per gram</description>
   </unit>
 
-  <!--amountOfSubstanceWeightFlux-->
-  <unit id="molesPerKilogramPerSecond" name="molesPerKilogramPerSecond" unitType="amountOfSubstanceWeightFlux" multiplierToSI="1">
-    <description>moles per kilogram per second</description>
+  <!--luminance-->
+  <unit id="candelaPerSquareMeter" name="candelaPerSquareMeter" unitType="luminance"
+    multiplierToSI="1" abbreviation="cd/m²" deprecatedInFavorOf="candelaPerMeterSquared"
+    udunitsSynonym="candela/meter^2">
+    <description>candela Per Square Meter (1 lux)</description>
   </unit>
-  <unit id="nanomolesPerGramPerSecond" name="nanomolesPerGramPerSecond" parentSI="molesPerKilogramPerSecond" multiplierToSI="0.000001" unitType="amountOfSubstanceWeightFlux">
-    <description>nanomoles Per Gram Per Second</description>
+
+  <unit id="candelaPerMeterSquared" name="candelaPerMeterSquared" unitType="luminance"
+    parentSI="candelaPerMeterSquared" multiplierToSI="1" abbreviation="cd/m²"
+    udunitsSynonym="candela/meter^2">
+    <description>candela Per Square Meter (1 lux)</description>
+  </unit>
+
+  <!--transmissivity-->
+  <unit id="metersSquaredPerSecond" name="metersSquaredPerSecond" unitType="transmissivity"
+    multiplierToSI="1" abbreviation="m²/s" deprecatedInFavorOf="meterSquaredPerSecond"
+    udunitsSynonym="meter^2/second">
+    <description>meters squared per second, SI unit for kinematic viscosity, specific relative 
+      angular momentum and thermal diffusivity. The unit may be better understood when phrased 
+      as "meter per second times meter" (velocity of an object with respect to a position).</description>
+  </unit>
+  <unit id="metersSquaredPerDay" name="metersSquaredPerDay" unitType="transmissivity"
+    parentSI="metersSquaredPerSecond" multiplierToSI="0.00001157407" abbreviation="m²/day"
+    deprecatedInFavorOf="meterSquaredPerDay" udunitsSynonym="meter^2/day">
+    <description>meters squared per day</description>
+  </unit>
+  <unit id="feetSquaredPerDay" name="feetSquaredPerDay" unitType="transmissivity"
+    parentSI="metersSquaredPerSecond" multiplierToSI="0.000001075267" abbreviation="ft²/day"
+    deprecatedInFavorOf="footSquaredPerDay" udunitsSynonym="international_foot^2/day">
+    <description>feet squared per day</description>
+  </unit>
+
+  <unit id="footSquaredPerDay" name="footSquaredPerDay" unitType="transmissivity"
+    parentSI="meterSquaredPerSecond" multiplierToSI="0.000001075267" abbreviation="ft²/d"
+    udunitsSynonym="international_foot^2/day">
+    <description>square feet per day</description>
+  </unit>
+  <unit id="meterSquaredPerDay" name="meterSquaredPerDay" unitType="transmissivity"
+    parentSI="meterSquaredPerSecond" multiplierToSI="0.00001157407" abbreviation="m²/d"
+    udunitsSynonym="meter^2/day">
+    <description>square meters per day</description>
+  </unit>
+  <unit id="meterSquaredPerSecond" name="meterSquaredPerSecond" unitType="transmissivity"
+    parentSI="meterSquaredPerSecond" multiplierToSI="1" abbreviation="m²/s"
+    udunitsSynonym="meter^2/second">
+    <description>meters squared per second, SI unit for kinematic viscosity, specific relative 
+      angular momentum and thermal diffusivity. The unit may be better understood when phrased 
+      as "meter per second times meter" (velocity of an object with respect to a position).</description>
   </unit>
 
   <!--massFlux-->
-  <unit id="kilogramsPerSecond" name="kilogramsPerSecond" unitType="massFlux" multiplierToSI="1" abbreviation="kg/s">
+  <unit id="kilogramsPerMeterSquaredPerSecond" name="kilogramsPerMeterSquaredPerSecond"
+    unitType="massFlux" multiplierToSI="1"
+    deprecatedInFavorOf="kilogramPerMeterSquaredPerSecond" udunitsSynonym="kilogram/meter^2/second">
+    <description>kilograms per meter sqared per second</description>
+  </unit>
+  <unit id="gramsPerCentimeterSquaredPerSecond" name="gramsPerCentimeterSquaredPerSecond"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="10"
+    deprecatedInFavorOf="gramPerCentimeterSquaredPerSecond"
+    udunitsSynonym="gram/centimeter^2/second">
+    <description>grams Per Centimeter Squared Per Second</description>
+  </unit>
+  <unit id="gramsPerMeterSquaredPerYear" name="gramsPerMeterSquaredPerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.0000000000317098" deprecatedInFavorOf="gramPerMeterSquaredPerYear"
+    udunitsSynonym="gram/meter^2/common_year">
+    <description>grams Per Meter Squared Per Year</description>
+  </unit>
+  <unit id="gramsPerHectarePerDay" name="gramsPerHectarePerDay" unitType="massFlux"
+    parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="0.0000000000011574"
+    deprecatedInFavorOf="gramPerDayPerHectare" udunitsSynonym="gram/hectare/day">
+    <description>grams Per Hectare Per Day</description>
+  </unit>
+  <unit id="kilogramsPerHectarePerYear" name="kilogramsPerHectarePerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.000000000003170979" deprecatedInFavorOf="kilogramPerHectarePerYear"
+    udunitsSynonym="kilogram/hectare/common_year">
+    <description>kilograms Per Hectare Per Year</description>
+  </unit>
+  <unit id="kilogramsPerMeterSquaredPerYear" name="kilogramsPerMeterSquaredPerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.00000003170979" deprecatedInFavorOf="kilogramPerMeterSquaredPerYear"
+    udunitsSynonym="kilogram/meter^2/common_year">
+    <description>kilograms Per Meter Squared Per Year</description>
+  </unit>
+
+  <unit id="gramPerCentimeterSquaredPerSecond" name="gramPerCentimeterSquaredPerSecond"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="10"
+    abbreviation="g/cm²/s" udunitsSynonym="gram/centimeter^2/second">
+    <description>grams per square centimeter per second</description>
+  </unit>
+  <unit id="gramPerDayPerHectare" name="gramPerDayPerHectare" unitType="massFlux"
+    parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="0.000000000001157407"
+    abbreviation="g/d/hectare" udunitsSynonym="gram/day/hectare">
+    <description>grams Per Hectare Squared Per Day</description>
+  </unit>
+  <unit id="gramPerMeterSquaredPerYear" name="gramPerMeterSquaredPerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.00000000003170979" abbreviation="g/m²/yr"
+    udunitsSynonym="gram/meter^2/common_year">
+    <description>grams per square meter per year</description>
+  </unit>
+  <unit id="kilogramPerHectarePerYear" name="kilogramPerHectarePerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.000000000003170979" abbreviation="kg/hectare/yr"
+    udunitsSynonym="kilogram/hectare/common_year">
+    <description>kilograms Per Hectare Per Year</description>
+  </unit>
+  <unit id="kilogramPerMeterSquaredPerSecond" name="kilogramPerMeterSquaredPerSecond"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="1"
+    abbreviation="kg/m²/s" udunitsSynonym="kilogram/meter^2/second">
+    <description>kilograms per square meter per second</description>
+  </unit>
+  <unit id="kilogramPerMeterSquaredPerDay" name="kilogramPerMeterSquaredPerDay"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="0.000015741"
+    abbreviation="kg/m²/d" udunitsSynonym="kilogram/meter^2/day">
+    <description>kilograms per square meter per day</description>
+  </unit>
+  <unit id="gramPerMeterSquaredPerDay" name="gramPerMeterSquaredPerDay"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="0.000000015741"
+    abbreviation="kg/m²/d" udunitsSynonym="kilogram/meter^2/day">
+    <description>grams per square meter per day</description>
+  </unit>
+  <unit id="milligramPerMeterSquaredPerDay" name="milligramPerMeterSquaredPerDay"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond" multiplierToSI="0.000000000015741"
+    abbreviation="mg/m²/d" udunitsSynonym="milligram/meter^2/day">
+    <description>milligram per square meter per day</description>
+  </unit>
+  <unit id="kilogramPerMeterSquaredPerYear" name="kilogramPerMeterSquaredPerYear"
+    unitType="massFlux" parentSI="kilogramPerMeterSquaredPerSecond"
+    multiplierToSI="0.00000003170979" abbreviation="kg/m²/yr"
+    udunitsSynonym="kilogram/meter^2/common_year">
+    <description>kilograms per square meter per year</description>
+  </unit>
+
+  <!--amountOfSubstanceWeight-->
+  <unit id="molesPerKilogram" name="molesPerKilogram" unitType="amountOfSubstanceWeight"
+    multiplierToSI="1" deprecatedInFavorOf="molePerKilogram" udunitsSynonym="mole/kilogram">
+    <description>moles per kilogram</description>
+  </unit>
+  <unit id="molesPerGram" name="molesPerGram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="1000" deprecatedInFavorOf="molePerGram"
+    udunitsSynonym="mole/gram">
+    <description>moles per gram</description>
+  </unit>
+  <unit id="millimolesPerGram" name="millimolesPerGram" unitType="amountOfSubstanceWeight"
+    parentSI="molePerKilogram" multiplierToSI="1" deprecatedInFavorOf="millimolePerGram"
+    udunitsSynonym="millimole/gram">
+    <description>millimoles per gram</description>
+  </unit>
+
+  <!--amountOfSubstanceWeightRate-->
+  <unit id="molesPerKilogramPerSecond" name="molesPerKilogramPerSecond"
+    unitType="amountOfSubstanceWeightRate" multiplierToSI="1"
+    deprecatedInFavorOf="molePerKilogramPerSecond" udunitsSynonym="mole/kilogram/second">
+    <description>moles per kilogram per second</description>
+  </unit>
+  <unit id="nanomolesPerGramPerSecond" name="nanomolesPerGramPerSecond"
+    parentSI="molePerKilogramPerSecond" multiplierToSI="0.000001"
+    unitType="amountOfSubstanceWeightRate" deprecatedInFavorOf="nanomolePerGramPerSecond"
+    udunitsSynonym="nanomole/gram/second">
+    <description>nanomoles Per Gram Per Second</description>
+  </unit>
+
+  <unit id="molePerKilogramPerSecond" name="molePerKilogramPerSecond"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond" multiplierToSI="1"
+    abbreviation="mol/kg/s" udunitsSynonym="mole/kilogram/second">
+    <description>moles per kilogram per second</description>
+  </unit>
+  <unit id="nanomolePerGramPerSecond" name="nanomolePerGramPerSecond"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.000001" abbreviation="nmol/g/s" udunitsSynonym="nanomole/gram/second">
+    <description>nanomoles Per Gram Per Second</description>
+  </unit>
+  <unit id="nanomolePerGramPerHour" name="nanomolePerGramPerHour"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.000000000277778" abbreviation="nmol/g/h" udunitsSynonym="nanomole/gram/hour">
+    <description>nanomoles Per Gram Per Hour</description>
+  </unit>
+  <unit id="nanomolePerGramPerDay" name="nanomolePerGramPerDay"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.0000000000115741" abbreviation="nmol/g/d" udunitsSynonym="nanomole/gram/day">
+    <description>nanomoles Per Gram Per day</description>
+  </unit>
+
+
+  <unit id="micromolePerGramPerSecond" name="micromolePerGramPerSecond"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.001" abbreviation="nmol/g/s" udunitsSynonym="micromole/gram/second">
+    <description>micromoles Per Gram Per Second</description>
+  </unit>
+  <unit id="micromolePerGramPerHour" name="micromolePerGramPerHour"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.000000277778" abbreviation="nmol/g/h" udunitsSynonym="micromole/gram/hour">
+    <description>micromoles Per Gram Per Hour</description>
+  </unit>
+  <unit id="micromolePerGramPerDay" name="micromolePerGramPerDay"
+    unitType="amountOfSubstanceWeightRate" parentSI="molePerKilogramPerSecond"
+    multiplierToSI="0.0000000115741" abbreviation="nmol/g/d" udunitsSynonym="micromole/gram/day">
+    <description>micromoles Per Gram Per day</description>
+  </unit>
+
+  <!--mass rates-->
+  <unit id="kilogramsPerSecond" name="kilogramsPerSecond" unitType="massRate" multiplierToSI="1"
+    abbreviation="kg/s" deprecatedInFavorOf="kilogramPerSecond" udunitsSynonym="kilogram/second">
     <description>kilograms per second</description>
   </unit>
-  <unit id="tonnesPerYear" name="tonnesPerYear" unitType="massFlux" parentSI="kilogramsPerSecond" multiplierToSI="0.0000317">
+  <unit id="tonnesPerYear" name="tonnesPerYear" unitType="massRate" parentSI="kilogramPerSecond"
+    multiplierToSI="0.0000317" deprecatedInFavorOf="tonnePerYear"
+    udunitsSynonym="metric_ton/common_year">
     <description>tonnes Per Year</description>
   </unit>
-  <unit id="gramsPerYear" name="gramsPerYear" unitType="massFlux" parentSI="kilogramsPerSecond" multiplierToSI="0.0000000000317" abbreviation="g/yr">
+  <unit id="gramsPerYear" name="gramsPerYear" unitType="massRate" parentSI="kilogramPerSecond"
+    multiplierToSI="0.0000000000317" abbreviation="g/yr" deprecatedInFavorOf="gramPerYear"
+    udunitsSynonym="gram/common_year">
     <description>grams Per Year</description>
   </unit>
 
-  <!--numeric densities-->
-  <unit id="numberPerMeterSquared" name="numberPerMeterSquared" unitType="arealDensity" multiplierToSI="1">
-    <description>number per meter squared</description>
+  <unit id="gramPerYear" name="gramPerYear" unitType="massRate" parentSI="kilogramPerSecond"
+    multiplierToSI="0.00000000003170979" abbreviation="g/yr" udunitsSynonym="gram/common_year">
+    <description>grams Per Year</description>
   </unit>
-  <unit id="numberPerKilometerSquared" name="numberPerKilometerSquared" unitType="arealDensity" parentSI="numberPerMeterSquared" multiplierToSI="0.000001">
+  <unit id="kilogramPerSecond" name="kilogramPerSecond" unitType="massRate"
+    parentSI="kilogramPerSecond" multiplierToSI="1" abbreviation="kg/s"
+    udunitsSynonym="kilogram/second">
+    <description>kilograms per second</description>
+  </unit>
+  <unit id="tonnePerYear" name="tonnePerYear" unitType="massRate" parentSI="kilogramPerSecond"
+    multiplierToSI="0.00003170979" abbreviation="t/yr" udunitsSynonym="metric_ton/common_year">
+    <description>tonnes Per Year</description>
+  </unit>
+
+  <!--numeric densities-->
+  <unit id="numberPerMeterSquared" name="numberPerMeterSquared" unitType="arealDensity"
+    multiplierToSI="1" udunitsSynonym="count/meter^2">
+    <description>number per meter squared, e.g., for a population density.</description>
+  </unit>
+  <unit id="numberPerKilometerSquared" name="numberPerKilometerSquared" unitType="arealDensity"
+    parentSI="numberPerMeterSquared" multiplierToSI="0.000001" udunitsSynonym="count/kilometer^2">
     <description>number per kilometer squared</description>
   </unit>
 
+  <unit id="numberPerHectare" name="numberPerHectare" unitType="arealDensity"
+    parentSI="numberPerMeterSquared" multiplierToSI="0.0001" abbreviation="#/hectare"
+    udunitsSynonym="count/hectare">
+    <description>number per hectare</description>
+  </unit>
+
   <!--volumetricDensity-->
-  <unit id="numberPerMeterCubed" name="numberPerMeterCubed" unitType="volumetricDensity" multiplierToSI="1">
+  <unit id="numberPerMeterCubed" name="numberPerMeterCubed" unitType="volumetricDensity"
+    multiplierToSI="1" udunitsSynonym="count/meter^3">
     <description>number per meter cubed</description>
   </unit>
 
-  <unit id="numberPerLiter" name="numberPerLiter" unitType="volumetricDensity" parentSI="numberPerMeterCubed" multiplierToSI="0.001">
+  <unit id="numberPerLiter" name="numberPerLiter" unitType="volumetricDensity"
+    parentSI="numberPerMeterCubed" multiplierToSI="1000" udunitsSynonym="count/liter">
     <description>number of entities per liter</description>
   </unit>
 
-  <unit id="numberPerMilliliter" name="numberPerMilliliter" unitType="volumetricDensity" parentSI="numberPerMeterCubed" multiplierToSI="0.000001">
+  <unit id="numberPerMilliliter" name="numberPerMilliliter" unitType="volumetricDensity"
+    parentSI="numberPerMeterCubed" multiplierToSI="1000000" udunitsSynonym="count/milliliter">
     <description>number of entities per milliliter</description>
   </unit>
 
   <!--massSpecificLength-->
-  <unit id="metersPerGram" name="metersPerGram" unitType="massSpecificLength" multiplierToSI="1" abbreviation="m/g">
+  <unit id="metersPerGram" name="metersPerGram" unitType="massSpecificLength" multiplierToSI="1"
+    abbreviation="m/g" deprecatedInFavorOf="meterPerGram" udunitsSynonym="meter/gram">
+    <description>meters per gram</description>
+  </unit>
+
+  <unit id="meterPerGram" name="meterPerGram" unitType="massSpecificLength" parentSI="meterPerGram"
+    multiplierToSI="1" abbreviation="m/g" udunitsSynonym="meter/gram">
     <description>meters per gram</description>
   </unit>
 
   <!--massSpecificCount-->
-  <unit id="numberPerGram" name="numberPerGram" unitType="massSpecificCount" multiplierToSI="1">
+  <unit id="numberPerGram" name="numberPerGram" unitType="massSpecificCount" multiplierToSI="1"
+    udunitsSynonym="count/gram">
     <description>number of entities per gram</description>
   </unit>
 
   <!--massPerMass-->
-  <unit id="gramsPerGram" name="gramsPerGram" unitType="massPerMass" multiplierToSI="1">
+  <unit id="gramsPerGram" name="gramsPerGram" unitType="massPerMass" multiplierToSI="1"
+    deprecatedInFavorOf="gramPerGram" udunitsSynonym="gram/gram">
     <description>grams per gram</description>
   </unit>
-  <unit id="microgramsPerGram" name="microgramsPerGram" unitType="massPerMass" parentSI="gramsPerGram" multiplierToSI="0.000001">
+  <unit id="microgramsPerGram" name="microgramsPerGram" unitType="massPerMass"
+    parentSI="gramsPerGram" multiplierToSI="0.000001" deprecatedInFavorOf="microgramPerGram"
+    udunitsSynonym="microgram/gram">
     <description>micrograms per gram</description>
   </unit>
 
+  <unit id="gramPerGram" name="gramPerGram" unitType="massPerMass" parentSI="gramPerGram"
+    multiplierToSI="1" abbreviation="g/g" udunitsSynonym="gram/gram">
+    <description>grams per gram</description>
+  </unit>
+  <unit id="milligramPerKilogram" name="milligramPerKilogram" unitType="massPerMass"
+    parentSI="gramPerGram" multiplierToSI="0.000001" abbreviation="mg/kg"
+    udunitsSynonym="milligram/kilogram">
+    <description>milligrams per kilogram</description>
+  </unit>
+  <unit id="microgramPerGram" name="microgramPerGram" unitType="massPerMass" parentSI="gramPerGram"
+    multiplierToSI="0.000001" abbreviation="μg/g" udunitsSynonym="microgram/gram">
+    <description>micrograms per gram</description>
+  </unit>
+  <unit id="nanogramPerGram" name="nanogramPerGram" unitType="massPerMass" parentSI="gramPerGram"
+    multiplierToSI="0.000000001" abbreviation="ng/g" udunitsSynonym="nanogram/gram">
+    <description>micrograms per gram</description>
+  </unit>
+
+<!-- mass per mass rate (mass-specific rate) -->
+  <unit id="microgramPerGramPerHour" name="microgramPerGramPerHour" unitType="massPerMassRate" parentSI="gramPerGramPerSecond"
+    multiplierToSI="0.000000000277778" abbreviation="μg/g/h" udunitsSynonym="microgram/gram/hour">
+    <description>micrograms per gram per hour</description>
+  </unit>
+  <unit id="microgramPerGramPerDay" name="microgramPerGramPerDay" unitType="massPerMassRate" parentSI="gramPerGramPerSecond"
+    multiplierToSI="0.0000000000115741" abbreviation="μg/g/day" udunitsSynonym="microgram/gram/day">
+    <description>micrograms per gram per day</description>
+  </unit>
+  <unit id="microgramPerGramPerWeek" name="microgramPerGramPerWeek" unitType="massPerMassRate" parentSI="gramPerGramPerSecond"
+    multiplierToSI="0.00000000000165344" abbreviation="μg/g/week" udunitsSynonym="microgram/gram/week">
+    <description>micrograms per gram per week</description>
+  </unit>
+  <unit id="nanogramPerGramPerHour" name="nanogramPerGramPerHour" unitType="massPerMassRate" parentSI="gramPerGramPerSecond"
+    multiplierToSI=" 0.000000277778" abbreviation="ng/g" udunitsSynonym="nanogram/gram/hour">
+    <description>nanoograms per gram per hour</description>
+  </unit>
+  
+
+
+
   <!--volumePerVolume-->
-  <unit id="cubicCentimetersPerCubicCentimeters" name="cubicCentimetersPerCubicCentimeters" unitType="volumePerVolume" multiplierToSI="1">
+  <unit id="cubicCentimetersPerCubicCentimeters" name="cubicCentimetersPerCubicCentimeters"
+    unitType="volumePerVolume" multiplierToSI="1" deprecatedInFavorOf="meterCubedPerMeterCubed"
+    udunitsSynonym="centimeter^3/centimeter^3">
     <description>cubic centimeters per cubic centimeter</description>
   </unit>
 
+  <unit id="meterCubedPerMeterCubed" name="meterCubedPerMeterCubed" unitType="volumePerVolume"
+    parentSI="meterCubedPerMeterCubed" multiplierToSI="1" abbreviation="m³/m³"
+    udunitsSynonym="meter^3/meter^3">
+    <description>milliliters per liter</description>
+  </unit>
+  <unit id="literPerLiter" name="literPerLiter" unitType="volumePerVolume"
+    parentSI="meterCubedPerMeterCubed" multiplierToSI="1" abbreviation="l/l"
+    udunitsSynonym="liter/liter">
+    <description>milliliters per liter</description>
+  </unit>
+  <unit id="milliliterPerLiter" name="milliliterPerLiter" unitType="volumePerVolume"
+    parentSI="meterCubedPerMeterCubed" multiplierToSI="0.001" abbreviation="ml/l"
+    udunitsSynonym="milliliter/liter">
+    <description>milliliters per liter</description>
+  </unit>
+  <unit id="microliterPerLiter" name="microliterPerLiter" unitType="volumePerVolume"
+    parentSI="meterCubedPerMeterCubed" multiplierToSI="0.000001" abbreviation="μl/l"
+    udunitsSynonym="microliter/liter">
+    <description>milliliters per liter</description>
+  </unit>
+  <unit id="nanoliterPerLiter" name="nanoliterPerLiter" unitType="volumePerVolume"
+    parentSI="meterCubedPerMeterCubed" multiplierToSI="0.000000001" abbreviation="nl/l"
+    udunitsSynonym="nanoliter/liter">
+    <description>milliliters per liter</description>
+  </unit>
 
+  <!--amountPerAmount-->
+  <unit id="molePerMole" name="molePerMole" unitType="" parentSI="molePerMole" multiplierToSI="1"
+    abbreviation="mol/mol" udunitsSynonym="mole/mole">
+    <description>millimoles per mole</description>
+  </unit>
+  <unit id="millimolePerMole" name="millimolePerMole" unitType="" parentSI="molePerMole"
+    multiplierToSI=".001" abbreviation="mmol/mol" udunitsSynonym="millimole/mole">
+    <description>millimoles per mole</description>
+  </unit>
+  <unit id="micromolePerMole" name="micromolePerMole" unitType="" parentSI="molePerMole"
+    multiplierToSI=".000001" abbreviation="μmol/mol" udunitsSynonym="micromole/mole">
+    <description>millimoles per mole</description>
+  </unit>
+  <unit id="nanomolePerMole" name="nanomolePerMole" unitType="" parentSI="molePerMole"
+    multiplierToSI=".000000001" abbreviation="nmol/mol" udunitsSynonym="nanomole/mole">
+    <description>millimoles per mole</description>
+  </unit>
 
+  <!--amountPerMass-->
+  <unit id="molePerKilogram" name="molePerKilogram" unitType="" parentSI="molePerKilogram"
+    multiplierToSI="1" abbreviation="mol/kg" udunitsSynonym="mole/kilogram">
+    <description>micromoles per kilogram</description>
+  </unit>
+  <unit id="millimolePerKilogram" name="millimolePerKilogram" unitType="" parentSI="molePerKilogram"
+    multiplierToSI="0.001" abbreviation="mmol/kg" udunitsSynonym="millimole/kilogram">
+    <description>micromoles per kilogram</description>
+  </unit>
+  <unit id="micromolePerKilogram" name="micromolePerKilogram" unitType="" parentSI="molePerKilogram"
+    multiplierToSI="0.000001" abbreviation="µmol/kg" udunitsSynonym="micromole/kilogram">
+    <description>micromoles per kilogram</description>
+  </unit>
+  <unit id="nanomolePerKilogram" name="nanomolePerKilogram" unitType="" parentSI="molePerKilogram"
+    multiplierToSI="0.000000001" abbreviation="nmol/kg" udunitsSynonym="nanomole/kilogram">
+    <description>micromoles per kilogram</description>
+  </unit>
+
+  <!--dimensionless-->
+  <unit id="percent" name="percent" unitType="dimensionless" parentSI="dimensionless"
+    multiplierToSI="1" abbreviation="%" udunitsSynonym="percent">
+    <description>percent, one part per hundred parts. a decimal ratio multipled by 100</description>
+  </unit>
+  <unit id="permil" name="permil" unitType="dimensionless" parentSI="dimensionless"
+    multiplierToSI="1" abbreviation="o/oo" udunitsSynonym="percent">
+    <description>permil, one part per thousand parts. a decimal ratio multipled by 1000</description>
+  </unit>
+<!-- irradiance (a flux) -->
+
+  <unit id="wattPerMeterSquared" name="wattPerMeterSquared" unitType=""
+    parentSI="wattPerMeterSquared" multiplierToSI="1" abbreviation="W/m²"
+    udunitsSynonym="watt/meter^2">
+    <description>watts per square meter, also, 1 kilogram per second cubed (ie, a flux)</description>
+  </unit>
+  <unit id="kilowattPerMeterSquared" name="kilowattPerMeterSquared" unitType=""
+    parentSI="wattPerMeterSquared" multiplierToSI="1000" abbreviation="kW/m²"
+    udunitsSynonym="kilowatt/meter^2">
+    <description>kilowatts per square meter</description>
+  </unit>
+  <unit id="wattPerMeterSquaredPerSteradian" name="wattPerMeterSquaredPerSteradian" unitType=""
+    parentSI="wattPerMeterSquaredPerSteradian" multiplierToSI="1" abbreviation="W/m²/sr"
+    udunitsSynonym="watt/meter^2/steradian">
+    <description>watts per square meter, in a solid angle</description>
+  </unit>
+  <unit id="microwattPerCentimeterSquaredPerSteradian" name="microwattPerCentimeterSquaredPerSteradian" unitType=""
+    parentSI="wattPerMeterSquaredPerSteradian" multiplierToSI="0.0000001" abbreviation="µW/cm²/sr"
+    udunitsSynonym="microwatt/centimeter^2/steradian">
+    <description>watts per square centimeter, in a solid angle</description>
+  </unit>
+  
+  <!-- spectral irradiances (a flux) -->
+  
+  <unit id="wattPerMeterSquaredPerNanometer" name="wattPerMeterSquaredPerNanometer" unitType=""
+    parentSI="wattPerMeterSquaredPerMeter" multiplierToSI="0.000000001" abbreviation="W/m²/nm"
+    udunitsSynonym="watt/meter^2/nm">
+    <description>watts per square meter, per unit of wavelength</description>
+  </unit>
+  
+  <unit id="microwattPerCentimeterSquaredPerNanometer" name="microwattPerCentimeterSquaredPerNanometer" unitType=""
+    parentSI="wattPerMeterSquaredPerMeter" multiplierToSI="0.0000001" abbreviation="µW/cm²/nm"
+    udunitsSynonym="microwatt/centimeter^2/nm">
+    <description>watts per square centimeter, per unit of wavelength</description>
+  </unit>
+
+  <unit id="wattPerMeterSquaredPerNanometerPerSteradian" name="wattPerMeterSquaredPerNanometerPerSteradian" unitType=""
+    parentSI="wattPerMeterSquaredPerMeterPerSteradian" multiplierToSI="0.000000001" abbreviation="W/m²/nm/sr"
+    udunitsSynonym="watt/meter^2/nm/steradian">
+    <description>watts per square meter, per unit of wavelength in a solid angle</description>
+  </unit>
+
+  <unit id="microwattPerCentimeterSquaredPerNanometerPerSteradian" name="microwattPerCentimeterSquaredPerNanometerPerSteradian" unitType=""
+    parentSI="wattPerMeterSquaredPerMeterPerSteradian" multiplierToSI="0.0000001" abbreviation="µW/cm²/nm/sr"
+    udunitsSynonym="microwatt/centimeter^2/nm/steradian">
+    <description>microwatts per square centimeter, per unit of wavelength, in a solid angle</description>
+  </unit>
+
+<!-- molar flux --> 
+  <unit id="molePerMeterSquaredPerSecond" name="molePerMeterSquaredPerSecond" unitType=""
+    parentSI="molePerMeterSquaredPerSecond" multiplierToSI="1" abbreviation="mol/m²/s"
+    udunitsSynonym="mole/meter^2/second">
+    <description>micromoles per square meter per second</description>
+  </unit>
+  <unit id="micromolePerMeterSquaredPerSecond" name="micromolePerMeterSquaredPerSecond" unitType=""
+    parentSI="molePerMeterSquaredPerSecond" multiplierToSI="0.000001" abbreviation="µmol/m²/s"
+    udunitsSynonym="micromole/meter^2/second">
+    <description>micromoles per square meter per second</description>
+  </unit>
+  <unit id="micromolePerCentimeterSquaredPerSecond" name="micromolePerCentimeterSquaredPerSecond" unitType=""
+    parentSI="molePerMeterSquaredPerSecond" multiplierToSI="0.01" abbreviation="µmol/cm²/s"
+    udunitsSynonym="micromole/centimeter^2/second">
+    <description>micromoles per square centimeter per second</description>
+  </unit>
+
+<!-- energy flux -->
+  <unit id="megajoulePerMeterSquaredPerDay" name="megajoulePerMeterSquaredPerDay" abbreviation="MJ/m2/day" 
+    unitType="arealEnergyDensityRate" parentSI="joulePerMeterSquaredPerSecond" multiplierToSI="11.5741" constantToSI="0"
+    udunitsSynonym="megajoule/m^2/day">
+    <description>megajoules per square meter per day</description>
+  </unit>
+  <unit id="langleyPerDay" name="langleyPerDay" abbreviation="Ly/day" 
+    unitType="arealEnergyDensityRate" parentSI="joulePerMeterSquaredPerSecond" multiplierToSI="0.484259" constantToSI="0"
+    udunitsSynonym="langley/day">
+    <description>Langley (Ly) per day. Ly is a unit of energy density = 41840 joule/m^2, = 1 calorie/cm^2</description>
+  </unit>
 </stmml:unitList>

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -11,3 +11,12 @@ testthat::test_that("we can use emld validator", {
 
 
 })
+
+
+testthat::test_that("validation uses the right unitDictionary", {
+  f <- system.file("tests", "eml-2.1.1", "invalid", "eml-2.1.1-invalidunit.xml", package = "emld")
+  testthat::expect_warning(eml_validate(f), "not recognized")
+
+  f <- system.file("tests", "eml-2.2.0", "eml-2.2.0-milligramPerLiter.xml", package = "emld")
+  testthat::expect_true(eml_validate(f))
+})


### PR DESCRIPTION
Fixes #56

While `eml_validate` determines the root schema to use when validating, `validate_units` was still defaulting to the version set in `emld_db`. This changes `validate_units` so it uses the appropriate `eml-unitDictionary.xml` file for the root element.

I've also added two test files and a test to exercise this so we know validate_units is working correctly now.