### PR TITLE
Wrap as_xml's output in `invisible`

### DIFF
--- a/R/as_xml.R
+++ b/R/as_xml.R
@@ -90,7 +90,7 @@ as_xml.emld <- function(x, file=NULL, root = "eml", ns = "eml",
 
   ## Serialize to file if desired
   if(!is.null(file)){
-    xml2::write_xml(xml, file)
+    invisible(xml2::write_xml(xml, file))
   } else {
     xml
   }


### PR DESCRIPTION
The docs indicate as_xml should return invisibly
when the file argument is specified but it
wasn't actually doing this.

Fixes #69